### PR TITLE
add specific types for scalar, points, private keys and public keys

### DIFF
--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -21,32 +21,6 @@ object Crypto {
   val zero = BigInteger.valueOf(0)
   val one = BigInteger.valueOf(1)
 
-  // a private key is just a number
-  type PrivateKey = Scalar
-
-  // a public key is a point on the secp256k1 curve
-  type PublicKey = Point
-
-  object PrivateKey {
-    def fromBase58(value: String, prefix: Byte): PrivateKey = {
-      require(Set(Base58.Prefix.SecretKey, Base58.Prefix.SecretKeyTestnet, Base58.Prefix.SecretKeySegnet).contains(prefix), "invalid base 58 prefix for a private key")
-      val (`prefix`, data) = Base58Check.decode(value)
-      Scalar(data)
-    }
-  }
-
-  object PublicKey {
-
-    sealed trait Encoding
-
-    case object Uncompressed extends Encoding
-
-    case object Compressed extends Encoding
-
-    case object Hybrid extends Encoding
-
-  }
-
   private def fixSize(data: BinaryData): BinaryData = data.length match {
     case 32 => data
     case length if length < 32 => Array.fill(32 - length)(0.toByte) ++ data
@@ -54,10 +28,9 @@ object Crypto {
 
   /**
     *
-    * @param value      value to initialize this scalar with
-    * @param compressed if true, points generated from this scalar will be compressed
+    * @param value value to initialize this scalar with
     */
-  case class Scalar(value: BigInteger, compressed: Boolean = true) {
+  case class Scalar(value: BigInteger) {
     def add(scalar: Scalar): Scalar = Scalar(value.add(scalar.value)).mod(Crypto.curve.getN)
 
     def substract(scalar: Scalar): Scalar = Scalar(value.subtract(scalar.value)).mod(Crypto.curve.getN)
@@ -66,27 +39,24 @@ object Crypto {
 
     /**
       *
-      * @return a binary representation of this value: 32 bytes if not compressed, 33 bytes with a last byte of '1' if compressed
+      * @return a 32 bytes binary representation of this value
       */
-    def toBin: BinaryData = {
-      val bin = fixSize(value.toByteArray.dropWhile(_ == 0))
-      if (compressed) bin :+ 1.toByte else bin
-    }
+    def toBin: BinaryData = fixSize(value.toByteArray.dropWhile(_ == 0))
 
     /**
       *
       * @return this * G where G is the curve generator
       */
-    def toPoint: Point = Point(params.getG().multiply(value), if (compressed) PublicKey.Compressed else PublicKey.Uncompressed)
+    def toPoint: Point = Point(params.getG().multiply(value))
+
+    override def toString = this.toBin.toString
   }
 
   object Scalar {
-    def apply(data: BinaryData): Scalar = data.length match {
-      case 32 => new Scalar(new BigInteger(1, data), compressed = false)
-      case 33 if data.last == 1 => new Scalar(new BigInteger(1, data.take(32).toArray), compressed = true)
+    def apply(data: BinaryData): Scalar = {
+      require(data.length == 32, "scalar must be initialized with a 32 bytes value")
+      new Scalar(new BigInteger(1, data))
     }
-
-    def apply(data: BinaryData, compressed: Boolean): Scalar = new Scalar(new BigInteger(1, data.take(32).toArray), compressed)
   }
 
   implicit def scalar2biginteger(scalar: Scalar): BigInteger = scalar.value
@@ -97,13 +67,49 @@ object Crypto {
 
   implicit def scalar2bin(scalar: Scalar): BinaryData = scalar.toBin
 
+  object PrivateKey {
+    def apply(data: BinaryData): PrivateKey = data.length match {
+      case 32 => new PrivateKey(Scalar(data), compressed = false)
+      case 33 if data.last == 1 => new PrivateKey(Scalar(data.take(32)), compressed = true)
+    }
+
+    def fromBase58(value: String, prefix: Byte): PrivateKey = {
+      require(Set(Base58.Prefix.SecretKey, Base58.Prefix.SecretKeyTestnet, Base58.Prefix.SecretKeySegnet).contains(prefix), "invalid base 58 prefix for a private key")
+      val (`prefix`, data) = Base58Check.decode(value)
+      PrivateKey(data)
+    }
+  }
+
+  /**
+    *
+    * @param value      value of this private key (a number)
+    * @param compressed flags which specifies if the associated public key will be compressed or uncompressed.
+    */
+  case class PrivateKey(value: Scalar, compressed: Boolean) {
+    /**
+      *
+      * @return the public key for this private key
+      */
+    def publicKey: PublicKey = PublicKey(value.toPoint, compressed)
+
+    /**
+      *
+      * @return the binary representation of this private key. It is either 32 bytes, or 33 bytes with final 0x1 if the
+      *         key is compressed
+      */
+    def toBin: BinaryData = if (compressed) value.toBin :+ 1.toByte else value.toBin
+
+    override def toString = toBin.toString
+  }
+
+  implicit def privatekey2scalar(priv: PrivateKey): Scalar = priv.value
+
   /**
     * Curve point
     *
-    * @param value    ecPoint to initialize this point with
-    * @param encoding if true, this point will be encoded in compressed format
+    * @param value ecPoint to initialize this point with
     */
-  case class Point(value: ECPoint, encoding: PublicKey.Encoding = PublicKey.Compressed) {
+  case class Point(value: ECPoint) {
     def add(point: Point): Point = Point(value.add(point.value))
 
     def multiply(scalar: Scalar): Point = Point(value.multiply(scalar.value))
@@ -112,7 +118,32 @@ object Crypto {
       *
       * @return a binary representation of this point in DER format
       */
-    def toBin: BinaryData = value.getEncoded(if (encoding == PublicKey.Uncompressed) false else true)
+    def toBin(compressed: Boolean): BinaryData = value.getEncoded(compressed)
+  }
+
+  object Point {
+    def apply(data: BinaryData): Point = Point(curve.getCurve.decodePoint(data))
+  }
+
+  implicit def point2ecpoint(point: Point): ECPoint = point.value
+
+  implicit def ecpoint2point(value: ECPoint): Point = Point(value)
+
+  object PublicKey {
+    def apply(data: BinaryData): PublicKey = data.length match {
+      case 65 if data.head == 4 => new PublicKey(Point(data), false)
+      case 65 if data.head == 6 || data.head == 7 => new PublicKey(Point(data), false)
+      case 33 if data.head == 2 || data.head == 3 => new PublicKey(Point(data), true)
+    }
+  }
+
+  /**
+    *
+    * @param value      value of this public key (a point)
+    * @param compressed flags which specifies if the associated public key will be compressed or uncompressed.
+    */
+  case class PublicKey(value: Point, compressed: Boolean) {
+    def toBin: BinaryData = value.toBin(compressed)
 
     /**
       *
@@ -121,26 +152,12 @@ object Crypto {
       */
     def hash160: BinaryData = Crypto.hash160(toBin)
 
-    def hash = hash160
+    override def toString = toBin.toString
   }
 
-  object Point {
-    def apply(data: BinaryData): Point = {
-      data.length match {
-        case 65 if data.head == 4 => Point(curve.getCurve.decodePoint(data), PublicKey.Uncompressed)
-        case 65 if data.head == 6 || data.head == 7 => Point(curve.getCurve.decodePoint(data), PublicKey.Hybrid)
-        case 33 if data.head == 2 || data.head == 3 => Point(curve.getCurve.decodePoint(data), PublicKey.Compressed)
-      }
-    }
-  }
+  implicit def publickey2point(pub: PublicKey): Point = pub.value
 
-  implicit def point2ecpoint(point: Point): ECPoint = point.value
-
-  implicit def ecpoint2point(value: ECPoint): Point = Point(value)
-
-  implicit def point2bin(point: Point): BinaryData = point.toBin
-
-  implicit def bin2point(data: BinaryData): Point = Point(data)
+  implicit def publickey2bin(pub: PublicKey): BinaryData = pub.toBin
 
   def hmac512(key: Seq[Byte], data: Seq[Byte]): BinaryData = {
     val mac = new HMac(new SHA512Digest())
@@ -323,7 +340,7 @@ object Crypto {
     */
   def sign(data: BinaryData, privateKey: PrivateKey): (BigInteger, BigInteger) = {
     val signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest))
-    val privateKeyParameters = new ECPrivateKeyParameters(privateKey, curve)
+    val privateKeyParameters = new ECPrivateKeyParameters(privateKey.value, curve)
     signer.init(true, privateKeyParameters)
     val Array(r, s) = signer.generateSignature(data.toArray)
 

--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -73,6 +73,8 @@ object Crypto {
       case 33 if data.last == 1 => new PrivateKey(Scalar(data.take(32)), compressed = true)
     }
 
+    def apply(data: BinaryData, compressed: Boolean): PrivateKey = new PrivateKey(Scalar(data.take(32)), compressed)
+
     def fromBase58(value: String, prefix: Byte): PrivateKey = {
       require(Set(Base58.Prefix.SecretKey, Base58.Prefix.SecretKeyTestnet, Base58.Prefix.SecretKeySegnet).contains(prefix), "invalid base 58 prefix for a private key")
       val (`prefix`, data) = Base58Check.decode(value)
@@ -85,7 +87,7 @@ object Crypto {
     * @param value      value of this private key (a number)
     * @param compressed flags which specifies if the associated public key will be compressed or uncompressed.
     */
-  case class PrivateKey(value: Scalar, compressed: Boolean) {
+  case class PrivateKey(value: Scalar, compressed: Boolean = true) {
     /**
       *
       * @return the public key for this private key
@@ -119,6 +121,8 @@ object Crypto {
       * @return a binary representation of this point in DER format
       */
     def toBin(compressed: Boolean): BinaryData = value.getEncoded(compressed)
+
+    override def toString = toBin(true).toString
   }
 
   object Point {
@@ -142,7 +146,7 @@ object Crypto {
     * @param value      value of this public key (a point)
     * @param compressed flags which specifies if the associated public key will be compressed or uncompressed.
     */
-  case class PublicKey(value: Point, compressed: Boolean) {
+  case class PublicKey(value: Point, compressed: Boolean = true) {
     def toBin: BinaryData = value.toBin(compressed)
 
     /**
@@ -328,7 +332,7 @@ object Crypto {
     * @param privateKey private key
     * @return the corresponding public key
     */
-  def publicKeyFromPrivateKey(privateKey: Seq[Byte]) = Scalar(privateKey).toPoint
+  def publicKeyFromPrivateKey(privateKey: BinaryData) = PrivateKey(privateKey).publicKey
 
   /**
     * Sign data with a private key, using RCF6979 deterministic signatures

--- a/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
+++ b/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
@@ -38,16 +38,16 @@ object DeterministicWallet {
     require(secretkeybytes.length == 32)
     require(chaincode.length == 32)
 
-    def privateKey: PrivateKey = Scalar(secretkeybytes :+ 1.toByte)
+    def privateKey: PrivateKey = PrivateKey(Scalar(secretkeybytes), compressed = true)
 
-    def publicKey: PublicKey = privateKey.toPoint
+    def publicKey: PublicKey = privateKey.publicKey
   }
 
   case class ExtendedPublicKey(publickeybytes: BinaryData, chaincode: BinaryData, depth: Int, path: KeyPath, parent: Long) {
     require(publickeybytes.length == 33)
     require(chaincode.length == 32)
 
-    def publicKey: PublicKey = Point(publickeybytes)
+    def publicKey: PublicKey = PublicKey(publickeybytes)
   }
 
   def encode(input: ExtendedPrivateKey, testnet: Boolean): String = {
@@ -95,7 +95,7 @@ object DeterministicWallet {
     * @return the public key for this private key
     */
   def publicKey(input: ExtendedPrivateKey): ExtendedPublicKey = {
-    ExtendedPublicKey(input.publicKey, input.chaincode, depth = input.depth, path = input.path, parent = input.parent)
+    ExtendedPublicKey(input.publicKey.toBin, input.chaincode, depth = input.depth, path = input.path, parent = input.parent)
   }
 
   /**

--- a/src/main/scala/fr/acinq/bitcoin/Protocol.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Protocol.scala
@@ -37,8 +37,12 @@ object Protocol {
 
   def uint16(input: InputStream, order: ByteOrder = ByteOrder.LITTLE_ENDIAN): Int = {
     val bin = new Array[Byte](2)
-    val buffer = ByteBuffer.wrap(bin).order(order)
     input.read(bin)
+    uint16(bin, order)
+  }
+
+  def uint16(input: BinaryData, order: ByteOrder): Int = {
+    val buffer = ByteBuffer.wrap(input).order(order)
     buffer.getShort & 0xFFFF
   }
 
@@ -53,8 +57,12 @@ object Protocol {
 
   def uint32(input: InputStream, order: ByteOrder = ByteOrder.LITTLE_ENDIAN): Long = {
     val bin = new Array[Byte](4)
-    val buffer = ByteBuffer.wrap(bin).order(order)
     input.read(bin)
+    uint32(bin, order)
+  }
+
+  def uint32(input: BinaryData, order: ByteOrder): Long = {
+    val buffer = ByteBuffer.wrap(input).order(order)
     buffer.getInt() & 0xFFFFFFFFL
   }
 
@@ -71,8 +79,12 @@ object Protocol {
 
   def uint64(input: InputStream, order: ByteOrder = ByteOrder.LITTLE_ENDIAN): Long = {
     val bin = new Array[Byte](8)
-    val buffer = ByteBuffer.wrap(bin).order(order)
     input.read(bin)
+    uint64(bin, order)
+  }
+
+  def uint64(input: BinaryData, order: ByteOrder): Long = {
+    val buffer = ByteBuffer.wrap(input).order(order)
     buffer.getLong()
   }
 

--- a/src/main/scala/fr/acinq/bitcoin/Script.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Script.scala
@@ -429,7 +429,7 @@ object Script {
         if (sigBytes1.isEmpty) false
         else {
           val hash = Transaction.hashForSigning(context.tx, context.inputIndex, scriptCode, sigHashFlags, context.amount, signatureVersion)
-          val result = Crypto.verifySignature(hash, sigBytes, Point(pubKey))
+          val result = Crypto.verifySignature(hash, sigBytes, PublicKey(pubKey))
           result
         }
       }
@@ -994,7 +994,7 @@ object Script {
     val op_m = ScriptElt.code2elt(m + 0x50)
     // 1 -> OP_1, 2 -> OP_2, ... 16 -> OP_16
     val op_n = ScriptElt.code2elt(pubkeys.size + 0x50)
-    op_m :: pubkeys.toList.map(OP_PUSHDATA(_)) ::: op_n :: OP_CHECKMULTISIG :: Nil
+    op_m :: pubkeys.toList.map(pub => OP_PUSHDATA(pub.toBin)) ::: op_n :: OP_CHECKMULTISIG :: Nil
   }
 
   /**
@@ -1002,7 +1002,7 @@ object Script {
     * @param pubKey public key
     * @return a pay-to-public-key-hash script
     */
-  def pay2pkh(pubKey: PublicKey): Seq[ScriptElt] = OP_DUP :: OP_HASH160 :: OP_PUSHDATA(pubKey.hash) :: OP_EQUALVERIFY :: OP_CHECKSIG :: Nil
+  def pay2pkh(pubKey: PublicKey): Seq[ScriptElt] = OP_DUP :: OP_HASH160 :: OP_PUSHDATA(pubKey.hash160) :: OP_EQUALVERIFY :: OP_CHECKSIG :: Nil
 
   /**
     *
@@ -1037,5 +1037,5 @@ object Script {
     * @param pubKey public key
     * @return a pay-to-witness-public-key-hash script
     */
-  def pay2wpkh(pubKey: PublicKey): Seq[ScriptElt] = OP_0 :: OP_PUSHDATA(pubKey.hash) :: Nil
+  def pay2wpkh(pubKey: PublicKey): Seq[ScriptElt] = OP_0 :: OP_PUSHDATA(pubKey.hash160) :: Nil
 }

--- a/src/main/scala/fr/acinq/bitcoin/Transaction.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Transaction.scala
@@ -432,7 +432,7 @@ object Transaction extends BtcMessage[Transaction] {
       val sig = signInput(input, i, signData(i).prevPubKeyScript, SIGHASH_ALL, signData(i).privateKey)
 
       // this is the public key that is associated with the private key we used for signing
-      val publicKey = Crypto.publicKeyFromPrivateKey(signData(i).privateKey)
+      val publicKey = signData(i).privateKey.publicKey
 
       // signature script: push signature and public key
       val sigScript = Script.write(OP_PUSHDATA(sig) :: OP_PUSHDATA(publicKey) :: Nil)
@@ -470,7 +470,7 @@ object Transaction extends BtcMessage[Transaction] {
 }
 
 object SignData {
-  def apply(prevPubKeyScript: Seq[ScriptElt], privateKey: BinaryData): SignData = new SignData(Script.write(prevPubKeyScript), privateKey)
+  def apply(prevPubKeyScript: Seq[ScriptElt], privateKey: PrivateKey): SignData = new SignData(Script.write(prevPubKeyScript), privateKey)
 }
 
 /**
@@ -479,7 +479,7 @@ object SignData {
   * @param prevPubKeyScript previous output public key script
   * @param privateKey       private key associated with the previous output public key
   */
-case class SignData(prevPubKeyScript: BinaryData, privateKey: BinaryData)
+case class SignData(prevPubKeyScript: BinaryData, privateKey: PrivateKey)
 
 /**
   * Transaction

--- a/src/test/scala/fr/acinq/bitcoin/CheckLockTimeVerifySpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CheckLockTimeVerifySpec.scala
@@ -1,5 +1,6 @@
 package fr.acinq.bitcoin
 
+import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.Script.{Context, Runner}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
@@ -10,21 +11,21 @@ class CheckLockTimeVerifySpec extends FlatSpec {
   "Bip65" should "let you initiate payment channels" in {
 
     val previousTx = Transaction.read("0100000001bb4f5a244b29dc733c56f80c0fed7dd395367d9d3b416c01767c5123ef124f82000000006b4830450221009e6ed264343e43dfee2373b925915f7a4468e0bc68216606e40064561e6c097a022030f2a50546a908579d0fab539d5726a1f83cfd48d29b89ab078d649a8e2131a0012103c80b6c289bf0421d010485cec5f02636d18fb4ed0f33bfa6412e20918ebd7a34ffffffff0200093d00000000001976a9145dbf52b8d7af4fb5f9b75b808f0a8284493531b388acf0b0b805000000001976a914807c74c89592e8a260f04b5a3bc63e7bef8c282588ac00000000")
-    val key = SignData(previousTx.txOut(0).publicKeyScript, Base58Check.decode("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs")._2)
+    val key = SignData(previousTx.txOut(0).publicKeyScript, PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet))
 
-    val keyAlice: BinaryData = "C0B91A94A26DC9BE07374C2280E43B1DE54BE568B2509EF3CE1ADE5C9CF9E8AA"
-    val pubAlice = Crypto.publicKeyFromPrivateKey(keyAlice)
+    val keyAlice = PrivateKey(BinaryData("C0B91A94A26DC9BE07374C2280E43B1DE54BE568B2509EF3CE1ADE5C9CF9E8AA"))
+    val pubAlice = keyAlice.publicKey
 
-    val keyBob: BinaryData = "5C3D081615591ABCE914D231BA009D8AE0174759E4A9AE821D97E28F122E2F8C"
-    val pubBob = Crypto.publicKeyFromPrivateKey(keyBob)
+    val keyBob = PrivateKey(BinaryData("5C3D081615591ABCE914D231BA009D8AE0174759E4A9AE821D97E28F122E2F8C"))
+    val pubBob = keyBob.publicKey
 
     // create a pub key script that can be redeemed either:
     // by Alice alone, in a tx which locktime is > 100
     // or by Alice and Bob, anytime
     val scriptPubKey = OP_IF ::
-      OP_PUSHDATA(Seq(100:Byte)) :: OP_CHECKLOCKTIMEVERIFY :: OP_DROP :: OP_PUSHDATA(pubAlice) :: OP_CHECKSIG ::
+      OP_PUSHDATA(Seq(100: Byte)) :: OP_CHECKLOCKTIMEVERIFY :: OP_DROP :: OP_PUSHDATA(pubAlice.toBin) :: OP_CHECKSIG ::
       OP_ELSE ::
-      OP_2 :: OP_PUSHDATA(pubAlice) :: OP_PUSHDATA(pubBob) :: OP_2 :: OP_CHECKMULTISIG :: OP_ENDIF :: Nil
+      OP_2 :: OP_PUSHDATA(pubAlice.toBin) :: OP_PUSHDATA(pubBob.toBin) :: OP_2 :: OP_CHECKMULTISIG :: OP_ENDIF :: Nil
 
     // create a tx that sends money to scriptPubKey
     val tx = {

--- a/src/test/scala/fr/acinq/bitcoin/MultisigSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/MultisigSpec.scala
@@ -6,18 +6,18 @@ import org.scalatest.{FlatSpec, Matchers}
 import Protocol._
 import Base58.Prefix
 import fr.acinq.bitcoin
-import fr.acinq.bitcoin.Crypto.Scalar
+import fr.acinq.bitcoin.Crypto.{PrivateKey, Scalar}
 
 @RunWith(classOf[JUnitRunner])
 class MultisigSpec extends FlatSpec with Matchers {
-  val key1 = Scalar(BinaryData("C0B91A94A26DC9BE07374C2280E43B1DE54BE568B2509EF3CE1ADE5C9CF9E8AA01"))
-  val pub1 = key1.toPoint
+  val key1 = PrivateKey(BinaryData("C0B91A94A26DC9BE07374C2280E43B1DE54BE568B2509EF3CE1ADE5C9CF9E8AA01"))
+  val pub1 = key1.publicKey
 
-  val key2 = Scalar(BinaryData("5C3D081615591ABCE914D231BA009D8AE0174759E4A9AE821D97E28F122E2F8C01"))
-  val pub2 = key2.toPoint
+  val key2 = PrivateKey(BinaryData("5C3D081615591ABCE914D231BA009D8AE0174759E4A9AE821D97E28F122E2F8C01"))
+  val pub2 = key2.publicKey
 
-  val key3 = Scalar(BinaryData("29322B8277C344606BA1830D223D5ED09B9E1385ED26BE4AD14075F054283D8C01"))
-  val pub3 = key3.toPoint
+  val key3 = PrivateKey(BinaryData("29322B8277C344606BA1830D223D5ED09B9E1385ED26BE4AD14075F054283D8C01"))
+  val pub3 = key3.publicKey
 
   val redeemScript: BinaryData = Script.write(Script.createMultiSigMofN(2, List(pub1, pub2, pub3)))
   val multisigAddress = Crypto.hash160(redeemScript)
@@ -46,8 +46,8 @@ class MultisigSpec extends FlatSpec with Matchers {
     val tx = Transaction(version = 1L, txIn = List(txIn), txOut = List(txOut), lockTime = 0L)
 
     val signData = SignData(
-      fromHexString("76a914298e5c1e2d2cf22deffd2885394376c7712f9c6088ac"), // PK script of 41e573704b8fba07c261a31c89ca10c3cb202c7e4063f185c997a8a87cf21dea
-      Base58Check.decode("92TgRLMLLdwJjT1JrrmTTWEpZ8uG7zpHEgSVPTbwfAs27RpdeWM")._2)
+      BinaryData("76a914298e5c1e2d2cf22deffd2885394376c7712f9c6088ac"), // PK script of 41e573704b8fba07c261a31c89ca10c3cb202c7e4063f185c997a8a87cf21dea
+      PrivateKey.fromBase58("92TgRLMLLdwJjT1JrrmTTWEpZ8uG7zpHEgSVPTbwfAs27RpdeWM", Base58.Prefix.SecretKeyTestnet))
 
     val signedTx = Transaction.sign(tx, List(signData))
 

--- a/src/test/scala/fr/acinq/bitcoin/SighashSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/SighashSpec.scala
@@ -13,7 +13,7 @@ class SighashSpec extends FunSuite {
       PrivateKey.fromBase58("cV5oyXUgySSMcUvKNdKtuYg4t4NTaxkwYrrocgsJZuYac2ogEdZX", Base58.Prefix.SecretKeyTestnet)
     )
 
-    val publicKeys = privateKeys.map(_.toPoint)
+    val publicKeys = privateKeys.map(_.publicKey)
 
     val previousTx = Seq(
       Transaction(version = 2, txIn = Nil, txOut = TxOut(42 millibtc, Script.pay2pkh(publicKeys(0))) :: Nil, lockTime = 0),
@@ -53,7 +53,7 @@ class SighashSpec extends FunSuite {
       PrivateKey.fromBase58("cV5oyXUgySSMcUvKNdKtuYg4t4NTaxkwYrrocgsJZuYac2ogEdZX", Base58.Prefix.SecretKeyTestnet)
     )
 
-    val publicKeys = privateKeys.map(_.toPoint)
+    val publicKeys = privateKeys.map(_.publicKey)
 
     val previousTx = Seq(
       Transaction(version = 2, txIn = Nil, txOut = TxOut(42 millibtc, Script.pay2wpkh(publicKeys(0))) :: Nil, lockTime = 0),

--- a/src/test/scala/fr/acinq/bitcoin/TransactionMalleabilitySpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionMalleabilitySpec.scala
@@ -1,5 +1,6 @@
 package fr.acinq.bitcoin
 
+import fr.acinq.bitcoin.Crypto.PrivateKey
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -11,7 +12,8 @@ class TransactionMalleabilitySpec extends FlatSpec {
     val prevTx = Transaction.read("01000000014a1140be18e3affa32a9561a3a4a75b9ed8b965a368a6f39fc57aee97c0eb4df010000006a4730440220363ce2ad434d16d8ca4f35866432fec887526bed328ec705af3a36cef1625fce0220579c0a7c57fe8a3691c833b78de7a3886a5e66422866e5d66cfcede2b8aaaac50121024034a310a6001ea45f7c9708c2f878c8ce42d715ceeaa2cd315af9d97baf85faffffffff02d0f9a800000000001976a91450ca5b3fb8268714ef48b0d46813df337dc5d5db88ac80969800000000001976a914d59dbfeedb94e9e66bd8b91af6caad082971b1b588ac00000000")
 
     // private key that matches the public key the btc we sent to in the tx we want to redeem
-    val (_, privateKey) = Base58Check.decode("cSjAjBx5zSuA16zhG2owyNCzkXLc7qJTz9M8aR6uK9S9QqS9P6gF")
+    val privateKey = PrivateKey.fromBase58("cSjAjBx5zSuA16zhG2owyNCzkXLc7qJTz9M8aR6uK9S9QqS9P6gF", Base58.Prefix.SecretKeyTestnet)
+    //    val (_, privateKey) = Base58Check.decode("cSjAjBx5zSuA16zhG2owyNCzkXLc7qJTz9M8aR6uK9S9QqS9P6gF")
 
     // public key we want to sent btc to
     val publicKey = BinaryData("03f1c059112166776c70367cc1a83851c6224e45f6fe3944442f7961072212f954")
@@ -36,7 +38,7 @@ class TransactionMalleabilitySpec extends FlatSpec {
     // step #2: sign the unsigned tx
     // signature script: push signature and public key
     val sig = Transaction.signInput(unsignedTx, 0, prevTx.txOut(1).publicKeyScript, SIGHASH_ALL, privateKey)
-    val signatureScript = OP_PUSHDATA(sig) :: OP_PUSHDATA(Crypto.publicKeyFromPrivateKey(privateKey)) :: Nil
+    val signatureScript = OP_PUSHDATA(sig) :: OP_PUSHDATA(privateKey.publicKey) :: Nil
 
     val tx1 = Transaction(version = 1,
       txIn = List(


### PR DESCRIPTION
the current design is clumsy and hard to use. creating scalar/point and
private key/public key types makes serialization easier to understand.