### PR TITLE
fix places using overflow int value 0xFFFFFFFF to the long value

### DIFF
--- a/src/main/scala/fr/acinq/bitcoin/Protocol.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Protocol.scala
@@ -71,7 +71,7 @@ object Protocol {
   def writeUInt32(input: Long, order: ByteOrder): Array[Byte] = {
     val bin = new Array[Byte](4)
     val buffer = ByteBuffer.wrap(bin).order(order)
-    buffer.putInt((input & 0xffffffff).toInt)
+    buffer.putInt((input & 0xffffffffL).toInt)
     bin
   }
 

--- a/src/main/scala/fr/acinq/bitcoin/Script.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Script.scala
@@ -166,7 +166,7 @@ object Script {
     case OP_PUSHDATA(data, length) :: tail if data.length < 0x4c && data.length == length => out.write(data.length); out.write(data); write(tail, out)
     case OP_PUSHDATA(data, 0x4c) :: tail if data.length < 0xff => writeUInt8(0x4c, out); writeUInt8(data.length, out); out.write(data); write(tail, out)
     case OP_PUSHDATA(data, 0x4d) :: tail if data.length < 0xffff => writeUInt8(0x4d, out); writeUInt16(data.length, out); out.write(data); write(tail, out)
-    case OP_PUSHDATA(data, 0x4e) :: tail if data.length < 0xffffffff => writeUInt8(0x4e, out); writeUInt32(data.length, out); out.write(data); write(tail, out)
+    case OP_PUSHDATA(data, 0x4e) :: tail if data.length < 0xffffffffL => writeUInt8(0x4e, out); writeUInt32(data.length, out); out.write(data); write(tail, out)
     case op@OP_PUSHDATA(data, code) :: tail => throw new RuntimeException(s"invalid element $op")
     case head :: tail => out.write(elt2code(head)); write(tail, out)
   }

--- a/src/main/scala/fr/acinq/bitcoin/ScriptElt.scala
+++ b/src/main/scala/fr/acinq/bitcoin/ScriptElt.scala
@@ -119,7 +119,7 @@ object OP_PUSHDATA {
   def apply(data: BinaryData) = if (data.length < 0x4c) new OP_PUSHDATA(data, data.length)
   else if (data.length < 0xff) new OP_PUSHDATA(data, 0x4c)
   else if (data.length < 0xffff) new OP_PUSHDATA(data, 0x4d)
-  else if (data.length < 0xffffffff) new OP_PUSHDATA(data, 0x4e)
+  else if (data.length < 0xffffffffL) new OP_PUSHDATA(data, 0x4e)
   else throw new IllegalArgumentException(s"data is ${data.length}, too big for OP_PUSHDATA")
 
   def isMinimal(data: BinaryData, code: Int): Boolean = if (data.length == 0) code == ScriptElt.elt2code(OP_0)

--- a/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
@@ -25,7 +25,7 @@ class TransactionSpec extends FlatSpec with Matchers {
     out.write(srcTx) // tx in id
     writeUInt32(vout, out)
     writeScript(fromHexString("76a914ea2902457015b386bd2323b2b99591b96138d62a88ac"), out) //scriptPubKey of prev tx for signing
-    writeUInt32(0xffffffff, out) // sequence
+    writeUInt32(0xffffffffL, out) // sequence
     writeVarint(1, out) // number of outputs
     writeUInt64(amount, out)
     writeScript(destAdress, out) //output script
@@ -55,7 +55,7 @@ class TransactionSpec extends FlatSpec with Matchers {
     signedOut.write(srcTx) // tx in id
     writeUInt32(vout, signedOut) // output index
     writeScript(sigScript, signedOut)
-    writeUInt32(0xffffffff, signedOut) // sequence
+    writeUInt32(0xffffffffL, signedOut) // sequence
     writeVarint(1, signedOut) // number of outputs
     writeUInt64(amount, signedOut) // amount in satoshi
     writeScript(destAdress, signedOut) //output script

--- a/src/test/scala/fr/acinq/bitcoin/reference/ScriptSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/reference/ScriptSpec.scala
@@ -70,12 +70,12 @@ object ScriptSpec {
   def parseScriptFlags(strFlags: String): Int = if (strFlags.isEmpty) 0 else strFlags.split(",").map(mapFlagNames(_)).foldLeft(0)(_ | _)
 
   def creditTx(scriptPubKey: Array[Byte], amount: Btc) = Transaction(version = 1,
-    txIn = TxIn(OutPoint(new Array[Byte](32), -1), Script.write(OP_0 :: OP_0 :: Nil), 0xffffffff) :: Nil,
+    txIn = TxIn(OutPoint(new Array[Byte](32), -1), Script.write(OP_0 :: OP_0 :: Nil), 0xffffffffL) :: Nil,
     txOut = TxOut(amount, scriptPubKey) :: Nil,
     lockTime = 0)
 
   def spendingTx(scriptSig: Array[Byte], tx: Transaction) = Transaction(version = 1,
-    txIn = TxIn(OutPoint(Crypto.hash256(Transaction.write(tx)), 0), scriptSig, 0xffffffff) :: Nil,
+    txIn = TxIn(OutPoint(Crypto.hash256(Transaction.write(tx)), 0), scriptSig, 0xffffffffL) :: Nil,
     txOut = TxOut(tx.txOut(0).amount, Array.empty[Byte]) :: Nil,
     lockTime = 0)
 


### PR DESCRIPTION
Fixed places that using `0xFFFFFFFF` which is overflowing.
Because of the push data size limit, It's not critical because there is no need to make a transaction using `PUSH_DATA4`

this commit enables `OP_PUSHDATA("from 0xFFFF to 0xFFFFFFFF length value")`

ofc it end up causing an error `Push value size limit exceeded` when script run is called