### PR TITLE
Lazy initialization of PublicKey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>fr.acinq</groupId>
     <artifactId>bitcoin-lib_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.19-LAZYPUB-SNAPSHOT</version>
+    <version>0.9.19-SNAPSHOT</version>
     <description>Simple Scala Bitcoin library</description>
     <url>https://github.com/ACINQ/bitcoin-lib</url>
     <name>bitcoin-lib</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>fr.acinq</groupId>
     <artifactId>bitcoin-lib_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.19-SNAPSHOT</version>
+    <version>0.9.19-LAZYPUB-SNAPSHOT</version>
     <description>Simple Scala Bitcoin library</description>
     <url>https://github.com/ACINQ/bitcoin-lib</url>
     <name>bitcoin-lib</name>

--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -190,12 +190,17 @@ object Crypto {
 
   /**
     *
-    * @param value      value of this public key (a point)
-    * @param compressed flags which specifies if the public key is compressed or uncompressed. Compressed public keys are
-    *                   encoded on 33 bytes (first byte = sign of Y, then X on 32 bytes)
+    * @param raw          serialized value of this public key (a point)
+    * @param checkValid   indicates whether or not we check sure that this is a valid public key; this should be used
+    *                     carefully for optimization purposes
     */
-  case class PublicKey(raw: BinaryData) {
-    //require(isPubKeyCompressedOrUncompressed(raw))
+  case class PublicKey(raw: BinaryData, checkValid: Boolean = true) {
+    // we always make this very basic check
+    require(raw.size == 33 || raw.size == 65)
+    if (checkValid) {
+      // this is expensive and done only if needed
+      require(value.isInstanceOf[Point])
+    }
 
     lazy val compressed = isPubKeyCompressed(raw)
 

--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -196,7 +196,7 @@ object Crypto {
     */
   case class PublicKey(raw: BinaryData, checkValid: Boolean = true) {
     // we always make this very basic check
-    require(raw.size == 33 || raw.size == 65)
+    require(isPubKeyValid(raw))
     if (checkValid) {
       // this is expensive and done only if needed
       require(value.isInstanceOf[Point])
@@ -390,6 +390,12 @@ object Crypto {
     true
   }
 
+  /**
+    *
+    * @param key serialized public key
+    * @return true if the key is valid. Please not that this performs very basic tests and does not check that the
+    *         point represented by this key is actually valid.
+    */
   def isPubKeyValid(key: Seq[Byte]): Boolean = key.length match {
     case 65 if key(0) == 4 || key(0) == 6 || key(0) == 7 => true
     case 33 if key(0) == 2 || key(0) == 3 => true

--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -191,7 +191,7 @@ object Crypto {
   /**
     *
     * @param raw          serialized value of this public key (a point)
-    * @param checkValid   indicates whether or not we check sure that this is a valid public key; this should be used
+    * @param checkValid   indicates whether or not we check that this is a valid public key; this should be used
     *                     carefully for optimization purposes
     */
   case class PublicKey(raw: BinaryData, checkValid: Boolean = true) {

--- a/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
@@ -42,6 +42,15 @@ class CryptoSpec extends FlatSpec {
     assert(address === "19FgFQGZy47NcGTJ4hfNdGMwS8EATqoa1X")
   }
 
+  it should "validate public key at instantiation" in {
+    intercept[IllegalArgumentException] {
+      // by default we check
+      PublicKey("04" * 65)
+    }
+    // key is invalid but we don't check it
+    PublicKey("04" * 65, checkValid = false)
+  }
+
   it should "sign and verify signatures" in {
     val random = new Random()
     val privateKey = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)

--- a/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
@@ -43,7 +43,7 @@ class CryptoSpec extends FlatSpec {
   }
 
   it should "validate public key at instantiation" in {
-    intercept[IllegalArgumentException] {
+    intercept[Throwable] { // can be IllegalArgumentException or AssertFailException depending on whether spongycastle or libsecp256k1 is used
       // by default we check
       PublicKey("04" * 65)
     }
@@ -52,7 +52,6 @@ class CryptoSpec extends FlatSpec {
   }
 
   it should "sign and verify signatures" in {
-    val random = new Random()
     val privateKey = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)
     val publicKey = privateKey.publicKey
     val data = Crypto.sha256("this is a test".getBytes("UTF-8"))


### PR DESCRIPTION
For performance reasons, make it possible to not check that a newly created public key is valid (meaning that x and y corresponds to points on the curve). For example we might already have checked the public key in the past and are loading it from some kind of storage.

The verification is enabled by default so this change should be fully backward compatible.