### PR TITLE
Use 64B-encoded instead of DER-encoded signatures 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>fr.acinq</groupId>
     <artifactId>bitcoin-lib_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>0.12-SNAPSHOT</version>
+    <version>0.12-bin64-SNAPSHOT</version>
     <description>Simple Scala Bitcoin library</description>
     <url>https://github.com/ACINQ/bitcoin-lib</url>
     <name>bitcoin-lib</name>

--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -184,6 +184,12 @@ object Crypto {
 
   object PublicKey {
 
+    /**
+      * @param raw        serialized value of this public key (a point)
+      * @param checkValid indicates whether or not we check that this is a valid public key; this should be used
+      *                   carefully for optimization purposes
+      * @return
+      */
     def apply(raw: ByteVector, checkValid: Boolean = true): PublicKey = {
       val pub = new PublicKey(raw)
       if (checkValid) {
@@ -200,7 +206,7 @@ object Crypto {
       *
       * Note that this mutates the input array!
       *
-      * @param raw 33 or 65 bytes public key (will be mutated)
+      * @param key 33 or 65 bytes public key (will be mutated)
       * @return an immutable compressed public key
       */
     def toCompressedUnsafe(key: Array[Byte]): PublicKey = {
@@ -223,8 +229,6 @@ object Crypto {
   /**
     *
     * @param raw        serialized value of this public key (a point)
-    * @param checkValid indicates whether or not we check that this is a valid public key; this should be used
-    *                   carefully for optimization purposes
     */
   class PublicKey(val raw: ByteVector) extends Serializable {
     // we always make this very basic check

--- a/src/main/scala/fr/acinq/bitcoin/Protocol.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Protocol.scala
@@ -26,7 +26,21 @@ object ByteVector32 {
 
   def fromValidHex(str: String) = ByteVector32(ByteVector.fromValidHex(str))
 
-  implicit def hash32toByteVector(h: ByteVector32): ByteVector = h.bytes
+  implicit def byteVector32toByteVector(h: ByteVector32): ByteVector = h.bytes
+}
+
+case class ByteVector64(bytes: ByteVector) {
+  require(bytes.size == 64, s"size must be 64 bytes, is ${bytes.size} bytes")
+
+  override def toString: String = bytes.toHex
+}
+
+object ByteVector64 {
+  val Zeroes = ByteVector64(hex"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+
+  def fromValidHex(str: String) = ByteVector64(ByteVector.fromValidHex(str))
+
+  implicit def byteVector64toByteVector(h: ByteVector64): ByteVector = h.bytes
 }
 
 object Protocol {

--- a/src/main/scala/fr/acinq/bitcoin/Script.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Script.scala
@@ -439,7 +439,7 @@ object Script {
         if (sigBytes1.isEmpty) false
         else {
           val hash = Transaction.hashForSigning(context.tx, context.inputIndex, scriptCode, sigHashFlags, context.amount, signatureVersion)
-          val result = Crypto.verifySignature(hash, sigBytes1, PublicKey(pubKey))
+          val result = Crypto.verifySignatureDER(hash, sigBytes1, PublicKey(pubKey))
           result
         }
       }

--- a/src/main/scala/fr/acinq/bitcoin/Transaction.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Transaction.scala
@@ -391,8 +391,7 @@ object Transaction extends BtcSerializer[Transaction] {
   def signInput(tx: Transaction, inputIndex: Int, previousOutputScript: ByteVector, sighashType: Int, amount: Satoshi, signatureVersion: Int, privateKey: PrivateKey): ByteVector = {
     if (signatureVersion == SigVersion.SIGVERSION_WITNESS_V0) require(privateKey.compressed, "private key must be compressed in segwit")
     val hash = hashForSigning(tx, inputIndex, previousOutputScript, sighashType, amount, signatureVersion)
-    val (r, s) = Crypto.sign(hash, privateKey)
-    val sig = Crypto.encodeSignature(r, s)
+    val sig = Crypto.signDER(hash, privateKey)
     sig :+ (sighashType.toByte)
   }
 

--- a/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
@@ -69,9 +69,8 @@ class CryptoSpec extends FlatSpec {
     val privateKey = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)
     val publicKey = privateKey.publicKey
     val data = Crypto.sha256(ByteVector("this is a test".getBytes("UTF-8")))
-    val (r, s) = Crypto.sign(data, privateKey)
-    val encoded = Crypto.encodeSignature(r, s)
-    assert(Crypto.verifySignature(data, encoded, publicKey))
+    val sig = Crypto.signDER(data, privateKey)
+    assert(Crypto.verifySignatureDER(data, sig, publicKey))
   }
 
   it should "generate deterministic signatures" in {
@@ -110,7 +109,7 @@ class CryptoSpec extends FlatSpec {
 
     dataset.map {
       case (k, m, s) =>
-        val sig: ByteVector = Crypto.encodeSignature(Crypto.sign(Crypto.sha256(ByteVector.view(m.getBytes("UTF-8"))), PrivateKey(k)))
+        val sig: ByteVector = Crypto.signDER(Crypto.sha256(ByteVector.view(m.getBytes("UTF-8"))), PrivateKey(k))
         assert(sig == s)
     }
   }
@@ -148,7 +147,8 @@ class CryptoSpec extends FlatSpec {
     val priv = PrivateKey(hex"0101010101010101010101010101010101010101010101010101010101010101", compressed = true)
     val message = hex"0202020202020202020202020202020202020202020202020202020202020202"
     val pub = priv.publicKey
-    val (r, s) = Crypto.sign(message, priv)
+    val sig64 = Crypto.sign(message, priv)
+    val (r, s) = Crypto.decodeSignatureFrom64(sig64)
     val (pub1, pub2) = recoverPublicKey((r, s), message)
 
     assert(verifySignature(message, (r, s), pub1))
@@ -175,7 +175,8 @@ class CryptoSpec extends FlatSpec {
         case "recid" =>
           recid = rhs.toInt
           assert(priv.publicKey == pub)
-          val (r, s) = Crypto.sign(message, priv)
+          val sig64 = Crypto.sign(message, priv)
+          val (r, s) = Crypto.decodeSignatureFrom64(sig64)
           val (pub1, pub2) = recoverPublicKey((r, s), message)
           recid match {
             case 0 => assert(pub == pub1)
@@ -197,7 +198,8 @@ class CryptoSpec extends FlatSpec {
 
       val priv = PrivateKey(bytesMessage, compressed = true)
       val pub = priv.publicKey
-      val (r, s) = Crypto.sign(ByteVector.view(message), priv)
+      val sig64 = Crypto.sign(ByteVector.view(message), priv)
+      val (r, s) = Crypto.decodeSignatureFrom64(sig64)
       val (pub1, pub2) = recoverPublicKey((r, s), bytesMessage)
 
       assert(verifySignature(bytesMessage, (r, s), pub1))

--- a/src/test/scala/fr/acinq/bitcoin/Secp256k1Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/Secp256k1Spec.scala
@@ -24,7 +24,7 @@ class Secp256k1Spec extends FunSuite {
     for (i <- 0 until 1000) {
       Random.nextBytes(priv)
       Random.nextBytes(data)
-      val sig1: ByteVector = Crypto.encodeSignature(Crypto.sign(data, PrivateKey(ByteVector.view(priv), true)))
+      val sig1: ByteVector = Crypto.signDER(ByteVector.view(data), PrivateKey(ByteVector.view(priv), true))
       val sig2: ByteVector = ByteVector.view(NativeSecp256k1.sign(data, priv))
       assert(sig1 == sig2)
     }

--- a/src/test/scala/fr/acinq/bitcoin/SegwitSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/SegwitSpec.scala
@@ -29,7 +29,7 @@ class SegwitSpec extends FunSuite {
     val priv = PrivateKey(hex"619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb901")
     val pub = priv.publicKey
     val sig = hex"304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee"
-    assert(Crypto.verifySignature(hash, sig, pub))
+    assert(Crypto.verifySignatureDER(hash, sig, pub))
 
     val sigScript = hex"4830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01"
     val tx1 = tx.updateSigScript(0, sigScript)

--- a/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
@@ -33,8 +33,7 @@ class TransactionSpec extends FunSuite with Matchers {
     val hashed = Crypto.hash256(serialized)
     val pkey_encoded = ByteVector.fromValidBase58("92f9274aR3s6zd1vuAgxquv4KP5S5thJadF3k54NHuTV4fXL1vW")
     val pkey = PrivateKey(pkey_encoded.slice(1, pkey_encoded.size - 4))
-    val (r, s) = Crypto.sign(hashed, pkey)
-    val sig = Crypto.encodeSignature(r, s)
+    val sig = Crypto.signDER(hashed, pkey)
     // DER encoded
     val sigOut = new ByteArrayOutputStream()
     writeUInt8(sig.length.toInt + 1, sigOut) // +1 because of the hash code
@@ -99,8 +98,7 @@ class TransactionSpec extends FunSuite with Matchers {
     val hashed = Crypto.hash256(serializedTx1AndHashType)
 
     // step #4: sign transaction hash
-    val (r, s) = Crypto.sign(hashed, privateKey)
-    val sig = Crypto.encodeSignature(r, s) // DER encoded
+    val sig = Crypto.signDER(hashed, privateKey) // DER encoded
 
     // this is the public key that is associated to the private key we used for signing
     val publicKey = privateKey.publicKey
@@ -119,7 +117,7 @@ class TransactionSpec extends FunSuite with Matchers {
     ))
 
     // check signature
-    assert(Crypto.verifySignature(hashed, sig, publicKey))
+    assert(Crypto.verifySignatureDER(hashed, sig, publicKey))
 
     // check script
     Transaction.correctlySpends(tx2, Seq(previousTx), ScriptFlags.MANDATORY_SCRIPT_VERIFY_FLAGS)


### PR DESCRIPTION
NB: the libsecp256k1's JNI wrapper actually takes DER-encoded signatures
as input to `checkSig()` and output of `sign()`, which is a different
behavior from the underlying C code. This will have to be updated later.