### PR TITLE
Use compressed private and public keys

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "secp256k1"]
-	path = secp256k1
-	url = https://github.com/pm47/secp256k1.git

--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -170,6 +170,8 @@ object Crypto {
 
     def toBin: ByteVector = value
 
+    override def toString = toBin.toHex
+
     // used only if secp256k1 is not available
     lazy val ecpoint = curve.getCurve.decodePoint(value.toArray)
   }

--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -33,9 +33,10 @@ object Crypto {
   def fixSize(data: ByteVector): ByteVector32 = ByteVector32(data.padLeft(32))
 
   /**
-    * A scalar is a 256 bit number
+    * Secp256k1 private key, which a 32 bytes value
+    * We assume that private keys are compressed i.e. that the corresponding public key is compressed
     *
-    * @param value value to initialize this scalar with
+    * @param value value to initialize this key with
     */
   case class PrivateKey(value: ByteVector32) {
     def add(that: PrivateKey): PrivateKey = if (Secp256k1Context.isEnabled)
@@ -132,9 +133,10 @@ object Crypto {
   }
 
   /**
-    * Curve point
+    * Secp256k1 Public key
+    * We assume that public keys are always compressed
     *
-    * @param value ecPoint to initialize this point with
+    * @param value serialized public key, in compressed format (33 bytes)
     */
   case class PublicKey(value: ByteVector) {
     require(value.length == 33)
@@ -413,8 +415,6 @@ object Crypto {
     case 33 if key(0) == 2 || key(0) == 3 => true
     case _ => false
   }
-
-  //def isPrivateKeyCompressed(key: PrivateKey): Boolean = key.compressed
 
   def isDefinedHashtypeSignature(sig: ByteVector): Boolean = if (sig.isEmpty) false
   else {

--- a/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
+++ b/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
@@ -138,7 +138,7 @@ object DeterministicWallet {
     * @return the public key for this private key
     */
   def publicKey(input: ExtendedPrivateKey): ExtendedPublicKey = {
-    ExtendedPublicKey(input.publicKey.toBin, input.chaincode, depth = input.depth, path = input.path, parent = input.parent)
+    ExtendedPublicKey(input.publicKey.value, input.chaincode, depth = input.depth, path = input.path, parent = input.parent)
   }
 
   /**
@@ -180,7 +180,7 @@ object DeterministicWallet {
     if (key.isZero) {
       throw new RuntimeException("cannot generated child private key")
     }
-    val buffer = ByteVector32(key.toBin.take(32))
+    val buffer = key.value
     ExtendedPrivateKey(buffer, chaincode = IR, depth = parent.depth + 1, path = parent.path.derive(index), parent = fingerprint(parent))
   }
 
@@ -204,7 +204,7 @@ object DeterministicWallet {
     if (Ki.ecpoint.isInfinity) {
       throw new RuntimeException("cannot generated child public key")
     }
-    val buffer = Ki.toBin
+    val buffer = Ki.value
     ExtendedPublicKey(buffer, chaincode = IR, depth = parent.depth + 1, path = parent.path.derive(index), parent = fingerprint(parent))
   }
 

--- a/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
+++ b/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
@@ -52,7 +52,7 @@ object DeterministicWallet {
 
   case class ExtendedPrivateKey(secretkeybytes: ByteVector32, chaincode: ByteVector32, depth: Int, path: KeyPath, parent: Long) {
 
-    def privateKey: PrivateKey = PrivateKey(secretkeybytes, compressed = true)
+    def privateKey: PrivateKey = PrivateKey(secretkeybytes)
 
     def publicKey: PublicKey = privateKey.publicKey
   }
@@ -200,7 +200,7 @@ object DeterministicWallet {
     if (p.compareTo(Crypto.curve.getN) >= 0) {
       throw new RuntimeException("cannot generated child public key")
     }
-    val Ki = PrivateKey(p, true).publicKey.add(parent.publicKey)
+    val Ki = PrivateKey(p).publicKey.add(parent.publicKey)
     if (Ki.ecpoint.isInfinity) {
       throw new RuntimeException("cannot generated child public key")
     }

--- a/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
+++ b/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.math.BigInteger
 import java.nio.ByteOrder
 
-import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey, Scalar}
+import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.Protocol._
 import scodec.bits.ByteVector
 
@@ -52,7 +52,7 @@ object DeterministicWallet {
 
   case class ExtendedPrivateKey(secretkeybytes: ByteVector32, chaincode: ByteVector32, depth: Int, path: KeyPath, parent: Long) {
 
-    def privateKey: PrivateKey = PrivateKey(Scalar(secretkeybytes), compressed = true)
+    def privateKey: PrivateKey = PrivateKey(secretkeybytes, compressed = true)
 
     def publicKey: PublicKey = privateKey.publicKey
   }
@@ -176,7 +176,7 @@ object DeterministicWallet {
       throw new RuntimeException("cannot generated child private key")
     }
 
-    val key = Scalar(IL).add(parent.privateKey)
+    val key = PrivateKey(IL).add(parent.privateKey)
     if (key.isZero) {
       throw new RuntimeException("cannot generated child private key")
     }
@@ -200,11 +200,11 @@ object DeterministicWallet {
     if (p.compareTo(Crypto.curve.getN) >= 0) {
       throw new RuntimeException("cannot generated child public key")
     }
-    val Ki = Scalar(p).toPoint.add(parent.publicKey)
+    val Ki = PrivateKey(p, true).publicKey.add(parent.publicKey)
     if (Ki.ecpoint.isInfinity) {
       throw new RuntimeException("cannot generated child public key")
     }
-    val buffer = Ki.toBin(true)
+    val buffer = Ki.toBin
     ExtendedPublicKey(buffer, chaincode = IR, depth = parent.depth + 1, path = parent.path.derive(index), parent = fingerprint(parent))
   }
 

--- a/src/main/scala/fr/acinq/bitcoin/Script.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Script.scala
@@ -1011,7 +1011,7 @@ object Script {
     val op_m = ScriptElt.code2elt(m + 0x50)
     // 1 -> OP_1, 2 -> OP_2, ... 16 -> OP_16
     val op_n = ScriptElt.code2elt(pubkeys.size + 0x50)
-    op_m :: pubkeys.toList.map(pub => OP_PUSHDATA(pub.toBin)) ::: op_n :: OP_CHECKMULTISIG :: Nil
+    op_m :: pubkeys.toList.map(pub => OP_PUSHDATA(pub.value)) ::: op_n :: OP_CHECKMULTISIG :: Nil
   }
 
   /**

--- a/src/main/scala/fr/acinq/bitcoin/Script.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Script.scala
@@ -439,7 +439,7 @@ object Script {
         if (sigBytes1.isEmpty) false
         else {
           val hash = Transaction.hashForSigning(context.tx, context.inputIndex, scriptCode, sigHashFlags, context.amount, signatureVersion)
-          val result = Crypto.verifySignature(hash, Crypto.der2compact(sigBytes1), PublicKey(pubKey))
+          val result = Crypto.verifySignature(hash, Crypto.der2compact(sigBytes1), PublicKey.deserialize(pubKey))
           result
         }
       }

--- a/src/main/scala/fr/acinq/bitcoin/Script.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Script.scala
@@ -431,7 +431,7 @@ object Script {
       if (sigBytes.isEmpty) false
       else if (!Crypto.checkSignatureEncoding(sigBytes, scriptFlag)) throw new RuntimeException("invalid signature")
       else if (!Crypto.checkPubKeyEncoding(pubKey, scriptFlag, signatureVersion)) throw new RuntimeException("invalid public key")
-      else if (!Crypto.isPubKeyValid(pubKey)) false // see how this is different from above ?
+      else if (!Crypto.isPubKeyValidLax(pubKey)) false // see how this is different from above ?
       else {
         val sigHashFlags = sigBytes.last & 0xff
         // sig hash is the last byte
@@ -439,7 +439,7 @@ object Script {
         if (sigBytes1.isEmpty) false
         else {
           val hash = Transaction.hashForSigning(context.tx, context.inputIndex, scriptCode, sigHashFlags, context.amount, signatureVersion)
-          val result = Crypto.verifySignature(hash, Crypto.der2compact(sigBytes1), PublicKey.deserialize(pubKey))
+          val result = Crypto.verifySignature(hash, Crypto.der2compact(sigBytes1), PublicKey.fromBin(pubKey))
           result
         }
       }

--- a/src/main/scala/fr/acinq/bitcoin/ScriptElt.scala
+++ b/src/main/scala/fr/acinq/bitcoin/ScriptElt.scala
@@ -1,5 +1,6 @@
 package fr.acinq.bitcoin
 
+import fr.acinq.bitcoin.Crypto.PublicKey
 import scodec.bits.ByteVector
 
 // @formatter:off
@@ -123,6 +124,8 @@ object OP_PUSHDATA {
   else if (data.length < 0xffff) new OP_PUSHDATA(data, 0x4d)
   else if (data.length < 0xffffffff) new OP_PUSHDATA(data, 0x4e)
   else throw new IllegalArgumentException(s"data is ${data.length}, too big for OP_PUSHDATA")
+
+  def apply(pub: PublicKey): OP_PUSHDATA = OP_PUSHDATA(pub.value)
 
   def isMinimal(data: ByteVector, code: Int): Boolean = if (data.length == 0) code == ScriptElt.elt2code(OP_0)
   else if (data.length == 1 && data(0) >= 1 && data(0) <= 16) code == ScriptElt.elt2code(OP_1) + (data(0) - 1)

--- a/src/main/scala/fr/acinq/bitcoin/Transaction.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Transaction.scala
@@ -409,46 +409,7 @@ object Transaction extends BtcSerializer[Transaction] {
     */
   def signInput(tx: Transaction, inputIndex: Int, previousOutputScript: Seq[ScriptElt], sighashType: Int, amount: Satoshi, signatureVersion: Int, privateKey: PrivateKey): ByteVector =
     signInput(tx, inputIndex, Script.write(previousOutputScript), sighashType, amount, signatureVersion, privateKey)
-
-  /**
-    *
-    * @param tx                   input transaction
-    * @param inputIndex           index of the tx input that is being processed
-    * @param previousOutputScript public key script of the output claimed by this tx input
-    * @param sighashType          signature hash type, which will be appended to the signature
-    * @param privateKey           private key
-    * @return the encoded signature of this tx for this specific tx input
-    */
-  @deprecated("", since = "0.9.6")
-  def signInput(tx: Transaction, inputIndex: Int, previousOutputScript: ByteVector, sighashType: Int, privateKey: PrivateKey): ByteVector =
-    signInput(tx, inputIndex, previousOutputScript, sighashType, amount = 0 satoshi, signatureVersion = SigVersion.SIGVERSION_BASE, privateKey)
-
-  /**
-    * Sign a transaction. Cannot partially sign. All the input are signed with SIGHASH_ALL
-    *
-    * @param input    transaction to sign
-    * @param signData list of data for signing: previous tx output script and associated private key
-    * @return a new signed transaction
-    */
-  def sign(input: Transaction, signData: Seq[SignData]): Transaction = {
-
-    require(signData.length == input.txIn.length, "There should be signing data for every transaction")
-
-    // sign each input
-    val signedInputs = for (i <- input.txIn.indices) yield {
-      val sig = signInput(input, i, signData(i).prevPubKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, signData(i).privateKey)
-
-      // this is the public key that is associated with the private key we used for signing
-      val publicKey = signData(i).privateKey.publicKey
-
-      // signature script: push signature and public key
-      val sigScript = Script.write(OP_PUSHDATA(sig) :: OP_PUSHDATA(publicKey) :: Nil)
-      input.txIn(i).copy(signatureScript = sigScript)
-    }
-
-    input.copy(txIn = signedInputs)
-  }
-
+  
   def correctlySpends(tx: Transaction, previousOutputs: Map[OutPoint, TxOut], scriptFlags: Int, callback: Option[Runner.Callback]): Unit = {
     for (i <- tx.txIn.indices if !OutPoint.isCoinbase(tx.txIn(i).outPoint)) {
       val prevOutput = previousOutputs(tx.txIn(i).outPoint)
@@ -475,18 +436,6 @@ object Transaction extends BtcSerializer[Transaction] {
   def correctlySpends(tx: Transaction, inputs: Seq[Transaction], scriptFlags: Int): Unit =
     correctlySpends(tx, inputs, scriptFlags, None)
 }
-
-object SignData {
-  def apply(prevPubKeyScript: Seq[ScriptElt], privateKey: PrivateKey): SignData = new SignData(Script.write(prevPubKeyScript), privateKey)
-}
-
-/**
-  * data for signing pay2pk transaction
-  *
-  * @param prevPubKeyScript previous output public key script
-  * @param privateKey       private key associated with the previous output public key
-  */
-case class SignData(prevPubKeyScript: ByteVector, privateKey: PrivateKey)
 
 /**
   * Transaction

--- a/src/main/scala/fr/acinq/bitcoin/Transaction.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Transaction.scala
@@ -389,7 +389,7 @@ object Transaction extends BtcSerializer[Transaction] {
     * @return the encoded signature of this tx for this specific tx input
     */
   def signInput(tx: Transaction, inputIndex: Int, previousOutputScript: ByteVector, sighashType: Int, amount: Satoshi, signatureVersion: Int, privateKey: PrivateKey): ByteVector = {
-    if (signatureVersion == SigVersion.SIGVERSION_WITNESS_V0) require(privateKey.compressed, "private key must be compressed in segwit")
+    //if (signatureVersion == SigVersion.SIGVERSION_WITNESS_V0) require(privateKey.compressed, "private key must be compressed in segwit")
     val hash = hashForSigning(tx, inputIndex, previousOutputScript, sighashType, amount, signatureVersion)
     val sig = Crypto.sign(hash, privateKey)
     Crypto.compact2der(sig) :+ (sighashType.toByte)

--- a/src/test/scala/fr/acinq/bitcoin/BIP49Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BIP49Spec.scala
@@ -20,7 +20,7 @@ class BIP49Spec extends FunSuite {
 
     val key = DeterministicWallet.derivePrivateKey(accountKey, 0L :: 0L :: Nil)
     assert(key.secretkeybytes == DeterministicWallet.derivePrivateKey(master, KeyPath("m/49'/1'/0'/0/0")).secretkeybytes)
-    assert(Base58Check.encode(Base58.Prefix.SecretKeyTestnet, key.privateKey.toBin) == "cULrpoZGXiuC19Uhvykx7NugygA3k86b3hmdCeyvHYQZSxojGyXJ")
+    assert(key.privateKey.toBase58(Base58.Prefix.SecretKeyTestnet) == "cULrpoZGXiuC19Uhvykx7NugygA3k86b3hmdCeyvHYQZSxojGyXJ")
     assert(key.privateKey == PrivateKey(hex"0xc9bdb49cfbaedca21c4b1f3a7803c34636b1d7dc55a717132443fc3f4c5867e801"))
     assert(key.publicKey == PublicKey(hex"0x03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f"))
     assert(computeBIP49Address(key.publicKey, Block.TestnetGenesisBlock.hash) == "2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2")

--- a/src/test/scala/fr/acinq/bitcoin/BIP84Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BIP84Spec.scala
@@ -22,19 +22,19 @@ class BIP84Spec extends FunSuite {
 
     val key = DeterministicWallet.derivePrivateKey(accountKey, 0L :: 0L :: Nil)
     assert(key.secretkeybytes == DeterministicWallet.derivePrivateKey(master, KeyPath("m/84'/0'/0'/0/0")).secretkeybytes)
-    assert(Base58Check.encode(Base58.Prefix.SecretKey, key.privateKey.toBin) == "KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d")
+    assert(key.privateKey.toBase58(Base58.Prefix.SecretKey) == "KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d")
     assert(key.publicKey == PublicKey(hex"0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c"))
     assert(computeBIP84Address(key.publicKey, Block.LivenetGenesisBlock.hash) == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
 
     val key1 = DeterministicWallet.derivePrivateKey(accountKey, 0L :: 1L :: Nil)
     assert(key1.secretkeybytes == DeterministicWallet.derivePrivateKey(master, KeyPath("m/84'/0'/0'/0/1")).secretkeybytes)
-    assert(Base58Check.encode(Base58.Prefix.SecretKey, key1.privateKey.toBin) == "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy")
+    assert(key1.privateKey.toBase58(Base58.Prefix.SecretKey) == "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy")
     assert(key1.publicKey == PublicKey(hex"03e775fd51f0dfb8cd865d9ff1cca2a158cf651fe997fdc9fee9c1d3b5e995ea77"))
     assert(computeBIP84Address(key1.publicKey, Block.LivenetGenesisBlock.hash) == "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g")
 
     val key2 = DeterministicWallet.derivePrivateKey(accountKey, 1L :: 0L :: Nil)
     assert(key2.secretkeybytes == DeterministicWallet.derivePrivateKey(master, KeyPath("m/84'/0'/0'/1/0")).secretkeybytes)
-    assert(Base58Check.encode(Base58.Prefix.SecretKey, key2.privateKey.toBin) == "KxuoxufJL5csa1Wieb2kp29VNdn92Us8CoaUG3aGtPtcF3AzeXvF")
+    assert(key2.privateKey.toBase58(Base58.Prefix.SecretKey) == "KxuoxufJL5csa1Wieb2kp29VNdn92Us8CoaUG3aGtPtcF3AzeXvF")
     assert(key2.publicKey == PublicKey(hex"03025324888e429ab8e3dbaf1f7802648b9cd01e9b418485c5fa4c1b9b5700e1a6"))
     assert(computeBIP84Address(key2.publicKey, Block.LivenetGenesisBlock.hash) == "bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el")
   }

--- a/src/test/scala/fr/acinq/bitcoin/CheckLockTimeVerifySpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CheckLockTimeVerifySpec.scala
@@ -8,7 +8,7 @@ class CheckLockTimeVerifySpec extends FlatSpec {
   "Bip65" should "let you initiate payment channels" in {
 
     val previousTx = Transaction.read("0100000001bb4f5a244b29dc733c56f80c0fed7dd395367d9d3b416c01767c5123ef124f82000000006b4830450221009e6ed264343e43dfee2373b925915f7a4468e0bc68216606e40064561e6c097a022030f2a50546a908579d0fab539d5726a1f83cfd48d29b89ab078d649a8e2131a0012103c80b6c289bf0421d010485cec5f02636d18fb4ed0f33bfa6412e20918ebd7a34ffffffff0200093d00000000001976a9145dbf52b8d7af4fb5f9b75b808f0a8284493531b388acf0b0b805000000001976a914807c74c89592e8a260f04b5a3bc63e7bef8c282588ac00000000")
-    val key = SignData(previousTx.txOut(0).publicKeyScript, PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet))
+    val key = SignData(previousTx.txOut(0).publicKeyScript, PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1)
 
     val keyAlice = PrivateKey(hex"C0B91A94A26DC9BE07374C2280E43B1DE54BE568B2509EF3CE1ADE5C9CF9E8AA")
     val pubAlice = keyAlice.publicKey

--- a/src/test/scala/fr/acinq/bitcoin/CheckLockTimeVerifySpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CheckLockTimeVerifySpec.scala
@@ -8,7 +8,8 @@ class CheckLockTimeVerifySpec extends FlatSpec {
   "Bip65" should "let you initiate payment channels" in {
 
     val previousTx = Transaction.read("0100000001bb4f5a244b29dc733c56f80c0fed7dd395367d9d3b416c01767c5123ef124f82000000006b4830450221009e6ed264343e43dfee2373b925915f7a4468e0bc68216606e40064561e6c097a022030f2a50546a908579d0fab539d5726a1f83cfd48d29b89ab078d649a8e2131a0012103c80b6c289bf0421d010485cec5f02636d18fb4ed0f33bfa6412e20918ebd7a34ffffffff0200093d00000000001976a9145dbf52b8d7af4fb5f9b75b808f0a8284493531b388acf0b0b805000000001976a914807c74c89592e8a260f04b5a3bc63e7bef8c282588ac00000000")
-    val key = SignData(previousTx.txOut(0).publicKeyScript, PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1)
+    //val key = SignData(previousTx.txOut(0).publicKeyScript, PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1)
+    val key = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1
 
     val keyAlice = PrivateKey(hex"C0B91A94A26DC9BE07374C2280E43B1DE54BE568B2509EF3CE1ADE5C9CF9E8AA")
     val pubAlice = keyAlice.publicKey
@@ -32,7 +33,8 @@ class CheckLockTimeVerifySpec extends FlatSpec {
         txOut = TxOut(amount = 100 satoshi, publicKeyScript = scriptPubKey) :: Nil,
         lockTime = 100L
       )
-      Transaction.sign(tmpTx, Seq(key))
+      val sig = Transaction.signInput(tmpTx, 0, previousTx.txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, key)
+      tmpTx.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(key.publicKey) :: Nil)
     }
 
     Transaction.correctlySpends(tx, Seq(previousTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)

--- a/src/test/scala/fr/acinq/bitcoin/CheckLockTimeVerifySpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CheckLockTimeVerifySpec.scala
@@ -21,9 +21,9 @@ class CheckLockTimeVerifySpec extends FlatSpec {
     // by Alice alone, in a tx which locktime is > 100
     // or by Alice and Bob, anytime
     val scriptPubKey = OP_IF ::
-      OP_PUSHDATA(ByteVector(100: Byte)) :: OP_CHECKLOCKTIMEVERIFY :: OP_DROP :: OP_PUSHDATA(pubAlice.toBin) :: OP_CHECKSIG ::
+      OP_PUSHDATA(ByteVector(100: Byte)) :: OP_CHECKLOCKTIMEVERIFY :: OP_DROP :: OP_PUSHDATA(pubAlice.value) :: OP_CHECKSIG ::
       OP_ELSE ::
-      OP_2 :: OP_PUSHDATA(pubAlice.toBin) :: OP_PUSHDATA(pubBob.toBin) :: OP_2 :: OP_CHECKMULTISIG :: OP_ENDIF :: Nil
+      OP_2 :: OP_PUSHDATA(pubAlice.value) :: OP_PUSHDATA(pubBob.value) :: OP_2 :: OP_CHECKMULTISIG :: OP_ENDIF :: Nil
 
     // create a tx that sends money to scriptPubKey
     val tx = {

--- a/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
@@ -28,18 +28,18 @@ class CryptoSpec extends FlatSpec {
   it should "generate public keys from private keys" in {
     val privateKey = PrivateKey(hex"18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725")
     val publicKey = privateKey.publicKey
-    assert(publicKey.serialize(false) === hex"0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6")
+    assert(publicKey.toUncompressedBin === hex"0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6")
 
-    val address = Base58Check.encode(Prefix.PubkeyAddress, Crypto.hash160(publicKey.serialize(false)))
+    val address = Base58Check.encode(Prefix.PubkeyAddress, Crypto.hash160(publicKey.toUncompressedBin))
     assert(address === "16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM")
   }
 
   it should "generate public keys from private keys 2" in {
     val privateKey = PrivateKey(hex"BCF69F7AFF3273B864F9DD76896FACE8E3D3CF69A133585C8177816F14FC9B55")
     val publicKey = privateKey.publicKey
-    assert(publicKey.serialize(false) === hex"04D7E9DD0C618C65DC2E3972E2AA406CCD34E5E77895C96DC48AF0CB16A1D9B8CE0C0A3E2F4CD494FF54FBE4F5A95B410C0BF022EB2B6F23AE39F40DB79FAA6827")
+    assert(publicKey.toUncompressedBin === hex"04D7E9DD0C618C65DC2E3972E2AA406CCD34E5E77895C96DC48AF0CB16A1D9B8CE0C0A3E2F4CD494FF54FBE4F5A95B410C0BF022EB2B6F23AE39F40DB79FAA6827")
 
-    val address = Base58Check.encode(Prefix.PubkeyAddress, Crypto.hash160(publicKey.serialize(false)))
+    val address = Base58Check.encode(Prefix.PubkeyAddress, Crypto.hash160(publicKey.toUncompressedBin))
     assert(address === "19FgFQGZy47NcGTJ4hfNdGMwS8EATqoa1X")
   }
 
@@ -55,12 +55,12 @@ class CryptoSpec extends FlatSpec {
   it should "allow unsafe initialization of public keys" in {
     val privateKey = PrivateKey(hex"BCF69F7AFF3273B864F9DD76896FACE8E3D3CF69A133585C8177816F14FC9B55")
     val publicKey = privateKey.publicKey
-    val rawCompressed = publicKey.value
-    val rawUncompressed = publicKey.serialize(false)
+    val rawCompressed = publicKey.toBin
+    val rawUncompressed = publicKey.toUncompressedBin
     assert(rawCompressed.size == 33)
     assert(rawUncompressed.size == 65)
-    val publicKeyCompressed1 = PublicKey.toCompressedUnsafe(rawCompressed.toArray)
-    val publicKeyCompressed2 = PublicKey.toCompressedUnsafe(rawUncompressed.toArray)
+    val publicKeyCompressed1 = PublicKey.fromBin(rawCompressed)
+    val publicKeyCompressed2 = PublicKey.fromBin(rawUncompressed)
     assert(publicKey === publicKeyCompressed1)
     assert(publicKey === publicKeyCompressed2)
   }

--- a/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
@@ -26,7 +26,7 @@ class CryptoSpec extends FlatSpec {
 
   // see https://en.bitcoin.it/wiki/Technical_background_of_Bitcoin_addresses
   it should "generate public keys from private keys" in {
-    val privateKey = PrivateKey(hex"18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725")
+    val privateKey = PrivateKey(hex"18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725", false)
     val publicKey = privateKey.publicKey
     assert(publicKey.toBin === hex"0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6")
 
@@ -35,7 +35,7 @@ class CryptoSpec extends FlatSpec {
   }
 
   it should "generate public keys from private keys 2" in {
-    val privateKey = PrivateKey(hex"BCF69F7AFF3273B864F9DD76896FACE8E3D3CF69A133585C8177816F14FC9B55")
+    val privateKey = PrivateKey(hex"BCF69F7AFF3273B864F9DD76896FACE8E3D3CF69A133585C8177816F14FC9B55", false)
     val publicKey = privateKey.publicKey
     assert(publicKey.toBin === hex"04D7E9DD0C618C65DC2E3972E2AA406CCD34E5E77895C96DC48AF0CB16A1D9B8CE0C0A3E2F4CD494FF54FBE4F5A95B410C0BF022EB2B6F23AE39F40DB79FAA6827")
 

--- a/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
@@ -130,8 +130,8 @@ class CryptoSpec extends FlatSpec {
   it should "compare points correctly" in {
     val secret = Scalar(hex"0101010101010101010101010101010101010101010101010101010101010101")
     val p1 = secret.toPoint
-    val p2 = Point(p1.toBin(false))
-    val p3 = Point(p1.toBin(true))
+    val p2 = Point.fromDER(p1.toBin(false))
+    val p3 = Point.fromDER(p1.toBin(true))
     assert(p1 == p2)
     assert(p1 == p3)
 

--- a/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/CryptoSpec.scala
@@ -20,7 +20,7 @@ class CryptoSpec extends FlatSpec {
     val (version, data) = Base58Check.decode(privateKey)
     val priv = PrivateKey(data)
     val publicKey = priv.publicKey
-    val computedAddress = Base58Check.encode(Prefix.PubkeyAddressTestnet, Crypto.hash160(publicKey.toBin))
+    val computedAddress = Base58Check.encode(Prefix.PubkeyAddressTestnet, Crypto.hash160(publicKey.value))
     assert(computedAddress === address)
   }
 
@@ -55,7 +55,7 @@ class CryptoSpec extends FlatSpec {
   it should "allow unsafe initialization of public keys" in {
     val privateKey = PrivateKey(hex"BCF69F7AFF3273B864F9DD76896FACE8E3D3CF69A133585C8177816F14FC9B55")
     val publicKey = privateKey.publicKey
-    val rawCompressed = publicKey.toBin
+    val rawCompressed = publicKey.value
     val rawUncompressed = publicKey.toUncompressedBin
     assert(rawCompressed.size == 33)
     assert(rawUncompressed.size == 65)

--- a/src/test/scala/fr/acinq/bitcoin/MultisigSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/MultisigSpec.scala
@@ -43,7 +43,7 @@ class MultisigSpec extends FunSuite with Matchers {
 
     val priv = PrivateKey.fromBase58("92TgRLMLLdwJjT1JrrmTTWEpZ8uG7zpHEgSVPTbwfAs27RpdeWM", Base58.Prefix.SecretKeyTestnet)._1
     val sig = Transaction.signInput(tx, 0, hex"76a914298e5c1e2d2cf22deffd2885394376c7712f9c6088ac", SIGHASH_ALL, txOut.amount, SigVersion.SIGVERSION_BASE, priv)
-    val signedTx = tx.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(priv.publicKey.serialize(false)) :: Nil)
+    val signedTx = tx.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(priv.publicKey.toUncompressedBin) :: Nil)
 
     //this works because signature is not randomized
     assert(signedTx.toString == "0100000001ea1df27ca8a897c985f163407e2c20cbc310ca891ca361c207ba8f4b7073e541000000008b483045022100940f7bcb380fb6db698f71928bda8926f76305ff868919e8ef7729647606bf7702200d32f1231860cb7e6777447c4038627bee7f47bc54005f681b62ce71d4a6a7f10141042adeabf9817a4d34adf1fe8e0fd457a3c0c6378afd63325dbaaaccd4f254002f9cc4148f603beb0e874facd3a3e68f5d002a65c0d3658452a4e55a57f5c3b768ffffffff01a0bb0d000000000017a914a90003b4ddef4be46fc61e7f2167da9d234944e28700000000")

--- a/src/test/scala/fr/acinq/bitcoin/MultisigSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/MultisigSpec.scala
@@ -41,11 +41,9 @@ class MultisigSpec extends FunSuite with Matchers {
     // create a tx with empty)put signature scripts
     val tx = Transaction(version = 1L, txIn = List(txIn), txOut = List(txOut), lockTime = 0L)
 
-    val signData = SignData(
-      hex"76a914298e5c1e2d2cf22deffd2885394376c7712f9c6088ac", // PK script of 41e573704b8fba07c261a31c89ca10c3cb202c7e4063f185c997a8a87cf21dea
-      PrivateKey.fromBase58("92TgRLMLLdwJjT1JrrmTTWEpZ8uG7zpHEgSVPTbwfAs27RpdeWM", Base58.Prefix.SecretKeyTestnet))
-
-    val signedTx = Transaction.sign(tx, List(signData))
+    val priv = PrivateKey.fromBase58("92TgRLMLLdwJjT1JrrmTTWEpZ8uG7zpHEgSVPTbwfAs27RpdeWM", Base58.Prefix.SecretKeyTestnet)._1
+    val sig = Transaction.signInput(tx, 0, hex"76a914298e5c1e2d2cf22deffd2885394376c7712f9c6088ac", SIGHASH_ALL, txOut.amount, SigVersion.SIGVERSION_BASE, priv)
+    val signedTx = tx.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(priv.publicKey.serialize(false)) :: Nil)
 
     //this works because signature is not randomized
     assert(signedTx.toString == "0100000001ea1df27ca8a897c985f163407e2c20cbc310ca891ca361c207ba8f4b7073e541000000008b483045022100940f7bcb380fb6db698f71928bda8926f76305ff868919e8ef7729647606bf7702200d32f1231860cb7e6777447c4038627bee7f47bc54005f681b62ce71d4a6a7f10141042adeabf9817a4d34adf1fe8e0fd457a3c0c6378afd63325dbaaaccd4f254002f9cc4148f603beb0e874facd3a3e68f5d002a65c0d3658452a4e55a57f5c3b768ffffffff01a0bb0d000000000017a914a90003b4ddef4be46fc61e7f2167da9d234944e28700000000")

--- a/src/test/scala/fr/acinq/bitcoin/Secp256k1Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/Secp256k1Spec.scala
@@ -24,7 +24,7 @@ class Secp256k1Spec extends FunSuite {
     for (i <- 0 until 1000) {
       Random.nextBytes(priv)
       Random.nextBytes(data)
-      val sig1: ByteVector = Crypto.sign(ByteVector.view(data), PrivateKey(ByteVector.view(priv), true))
+      val sig1: ByteVector = Crypto.sign(ByteVector.view(data), PrivateKey(ByteVector.view(priv)))
       val sig2: ByteVector = ByteVector.view(NativeSecp256k1.signCompact(data, priv))
       assert(sig1 == sig2)
     }

--- a/src/test/scala/fr/acinq/bitcoin/Secp256k1Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/Secp256k1Spec.scala
@@ -1,6 +1,6 @@
 package fr.acinq.bitcoin
 
-import fr.acinq.bitcoin.Crypto.{PrivateKey, Scalar}
+import fr.acinq.bitcoin.Crypto.PrivateKey
 import org.bitcoin.{NativeSecp256k1, Secp256k1Context}
 import org.scalatest.FunSuite
 import scodec.bits.ByteVector
@@ -36,7 +36,7 @@ class Secp256k1Spec extends FunSuite {
     for (i <- 0 until 1000) {
       Random.nextBytes(priv1)
       Random.nextBytes(priv2)
-      val secret1: ByteVector = Crypto.ecdh(Scalar(ByteVector.view(priv1)), Scalar(ByteVector.view(priv2)).toPoint)
+      val secret1: ByteVector = Crypto.ecdh(PrivateKey(ByteVector.view(priv1)), PrivateKey(ByteVector.view(priv2)).publicKey)
       val secret2: ByteVector = ByteVector.view(NativeSecp256k1.createECDHSecret(priv1, NativeSecp256k1.computePubkey(priv2)))
       assert(secret1 == secret2)
     }

--- a/src/test/scala/fr/acinq/bitcoin/SegwitSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/SegwitSpec.scala
@@ -78,7 +78,8 @@ class SegwitSpec extends FunSuite {
         txOut = TxOut(0.39 btc, Script.pay2wpkh(pub1)) :: Nil,
         lockTime = 0
       )
-      Transaction.sign(tmp, Seq(SignData(tx1.txOut(0).publicKeyScript, priv1)))
+      val sig = Transaction.signInput(tmp, 0, tx1.txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, priv1)
+      tmp.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(priv1.publicKey) :: Nil)
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     assert(tx2.txid == ByteVector32(hex"3acf933cd1dbffbb81bb5c6fab816fdebf85875a3b77754a28f00d717f450e1e"))
@@ -129,7 +130,9 @@ class SegwitSpec extends FunSuite {
         txOut = TxOut(0.49 btc, Script.pay2wsh(redeemScript)) :: Nil,
         lockTime = 0
       )
-      Transaction.sign(tmp, Seq(SignData(tx1.txOut(0).publicKeyScript, priv1)))
+      val sig = Transaction.signInput(tmp, 0, tx1.txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, priv1)
+      tmp.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(priv1.publicKey) :: Nil)
+      //Transaction.sign(tmp, Seq(SignData(tx1.txOut(0).publicKeyScript, priv1)))
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     assert(tx2.txid == ByteVector32(hex"9d896b6d2b8fc9665da72f5b1942f924a37c5c714f31f40ee2a6c945f74dd355"))

--- a/src/test/scala/fr/acinq/bitcoin/SegwitSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/SegwitSpec.scala
@@ -62,7 +62,7 @@ class SegwitSpec extends FunSuite {
   }
 
   test("create p2wpkh tx") {
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)
+    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
     val pub1 = priv1.publicKey
     val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.toBin))
 
@@ -105,16 +105,16 @@ class SegwitSpec extends FunSuite {
   }
 
   test("create p2wsh tx") {
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)
+    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
     val pub1 = priv1.publicKey
     val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.toBin))
 
     assert(address1 == "D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap")
 
-    val priv2 = PrivateKey.fromBase58("QUpr3G5ia7K7txSq5k7QpgTfNy33iTQWb1nAUgb77xFesn89xsoJ", Base58.Prefix.SecretKeySegnet)
+    val priv2 = PrivateKey.fromBase58("QUpr3G5ia7K7txSq5k7QpgTfNy33iTQWb1nAUgb77xFesn89xsoJ", Base58.Prefix.SecretKeySegnet)._1
     val pub2 = priv2.publicKey
 
-    val priv3 = PrivateKey.fromBase58("QX3AN7b3WCAFaiCvAS2UD7HJZBsFU6r5shjfogJu55411hAF3BVx", Base58.Prefix.SecretKeySegnet)
+    val priv3 = PrivateKey.fromBase58("QX3AN7b3WCAFaiCvAS2UD7HJZBsFU6r5shjfogJu55411hAF3BVx", Base58.Prefix.SecretKeySegnet)._1
     val pub3 = priv3.publicKey
 
     // this is a standard tx that sends 0.5 BTC to D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap
@@ -155,7 +155,7 @@ class SegwitSpec extends FunSuite {
   }
 
   test("create p2pkh embedded in p2sh") {
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)
+    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
     val pub1 = priv1.publicKey
 
     // p2wpkh script

--- a/src/test/scala/fr/acinq/bitcoin/SegwitSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/SegwitSpec.scala
@@ -33,7 +33,7 @@ class SegwitSpec extends FunSuite {
 
     val sigScript = hex"4830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01"
     val tx1 = tx.updateSigScript(0, sigScript)
-    val tx2 = tx1.updateWitness(1, ScriptWitness((sig :+ SIGHASH_ALL.toByte) :: pub.toBin :: Nil))
+    val tx2 = tx1.updateWitness(1, ScriptWitness((sig :+ SIGHASH_ALL.toByte) :: pub.value :: Nil))
     assert(tx2.toString === "01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000")
   }
 
@@ -64,7 +64,7 @@ class SegwitSpec extends FunSuite {
   test("create p2wpkh tx") {
     val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
     val pub1 = priv1.publicKey
-    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.toBin))
+    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.value))
 
     assert(address1 == "D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap")
 
@@ -96,7 +96,7 @@ class SegwitSpec extends FunSuite {
       // of the pubkey hash), but the actual script that is evaluated by the script engine, in this case a PAY2PKH script
       val pubKeyScript = Script.pay2pkh(pub1)
       val sig = Transaction.signInput(tmp, 0, pubKeyScript, SIGHASH_ALL, tx2.txOut(0).amount, SigVersion.SIGVERSION_WITNESS_V0, priv1)
-      val witness = ScriptWitness(Seq(sig, pub1.toBin))
+      val witness = ScriptWitness(Seq(sig, pub1.value))
       tmp.updateWitness(0, witness)
     }
 
@@ -108,7 +108,7 @@ class SegwitSpec extends FunSuite {
   test("create p2wsh tx") {
     val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
     val pub1 = priv1.publicKey
-    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.toBin))
+    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.value))
 
     assert(address1 == "D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap")
 
@@ -176,12 +176,12 @@ class SegwitSpec extends FunSuite {
     val tx1 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx.hash, 1), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.49 btc, OP_0 :: OP_PUSHDATA(Crypto.hash160(pub1.toBin)) :: Nil) :: Nil,
+        txOut = TxOut(0.49 btc, OP_0 :: OP_PUSHDATA(Crypto.hash160(pub1.value)) :: Nil) :: Nil,
         lockTime = 0
       )
       val pubKeyScript = Script.pay2pkh(pub1)
       val sig = Transaction.signInput(tmp, 0, pubKeyScript, SIGHASH_ALL, tx.txOut(1).amount, SigVersion.SIGVERSION_WITNESS_V0, priv1)
-      val witness = ScriptWitness(Seq(sig, pub1.toBin))
+      val witness = ScriptWitness(Seq(sig, pub1.value))
       tmp.updateSigScript(0, OP_PUSHDATA(script) :: Nil).updateWitness(0, witness)
     }
 

--- a/src/test/scala/fr/acinq/bitcoin/SighashSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/SighashSpec.scala
@@ -68,7 +68,7 @@ class SighashSpec extends FunSuite {
     val tx1 = {
       val tmp = tx.addInput(TxIn(OutPoint(previousTx(0), 0), sequence = 0xFFFFFFFFL, signatureScript = Nil))
       val sig: ByteVector = Transaction.signInput(tmp, 0, Script.pay2pkh(publicKeys(0)), SIGHASH_ALL | SIGHASH_ANYONECANPAY, previousTx(0).txOut(0).amount, SigVersion.SIGVERSION_WITNESS_V0, privateKeys(0))
-      tmp.updateWitness(0, ScriptWitness(sig :: publicKeys(0).toBin :: Nil))
+      tmp.updateWitness(0, ScriptWitness(sig :: publicKeys(0).value :: Nil))
     }
     Transaction.correctlySpends(tx1, previousTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
@@ -76,7 +76,7 @@ class SighashSpec extends FunSuite {
     val tx2 = {
       val tmp = tx1.addInput(TxIn(OutPoint(previousTx(1), 0), sequence = 0xFFFFFFFFL, signatureScript = Nil))
       val sig: ByteVector = Transaction.signInput(tmp, 1, Script.pay2pkh(publicKeys(1)), SIGHASH_ALL | SIGHASH_ANYONECANPAY, previousTx(1).txOut(0).amount, SigVersion.SIGVERSION_WITNESS_V0, privateKeys(1))
-      tmp.updateWitness(1, ScriptWitness(sig :: publicKeys(1).toBin :: Nil))
+      tmp.updateWitness(1, ScriptWitness(sig :: publicKeys(1).value :: Nil))
     }
     Transaction.correctlySpends(tx2, previousTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 

--- a/src/test/scala/fr/acinq/bitcoin/SighashSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/SighashSpec.scala
@@ -28,7 +28,7 @@ class SighashSpec extends FunSuite {
     val tx1 = {
       val tmp = tx.addInput(TxIn(OutPoint(previousTx(0), 0), sequence = 0xFFFFFFFFL, signatureScript = Nil))
       val sig: ByteVector = Transaction.signInput(tmp, 0, Script.pay2pkh(publicKeys(0)), SIGHASH_ALL | SIGHASH_ANYONECANPAY, previousTx(0).txOut(0).amount, SigVersion.SIGVERSION_BASE, privateKeys(0))
-      tmp.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(publicKeys(0)) :: Nil)
+      tmp.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(publicKeys(0).value) :: Nil)
 
     }
     Transaction.correctlySpends(tx1, previousTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
@@ -37,7 +37,7 @@ class SighashSpec extends FunSuite {
     val tx2 = {
       val tmp = tx1.addInput(TxIn(OutPoint(previousTx(1), 0), sequence = 0xFFFFFFFFL, signatureScript = Nil))
       val sig: ByteVector = Transaction.signInput(tmp, 1, Script.pay2pkh(publicKeys(1)), SIGHASH_ALL | SIGHASH_ANYONECANPAY, previousTx(1).txOut(0).amount, SigVersion.SIGVERSION_BASE, privateKeys(1))
-      tmp.updateSigScript(1, OP_PUSHDATA(sig) :: OP_PUSHDATA(publicKeys(1)) :: Nil)
+      tmp.updateSigScript(1, OP_PUSHDATA(sig) :: OP_PUSHDATA(publicKeys(1).value) :: Nil)
     }
     Transaction.correctlySpends(tx2, previousTx, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 

--- a/src/test/scala/fr/acinq/bitcoin/SighashSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/SighashSpec.scala
@@ -10,8 +10,8 @@ import scodec.bits.ByteVector
 class SighashSpec extends FunSuite {
   test("SIGHASH_ANYONECANPAY lets you add inputs") {
     val privateKeys = List(
-      PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet),
-      PrivateKey.fromBase58("cV5oyXUgySSMcUvKNdKtuYg4t4NTaxkwYrrocgsJZuYac2ogEdZX", Base58.Prefix.SecretKeyTestnet)
+      PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1,
+      PrivateKey.fromBase58("cV5oyXUgySSMcUvKNdKtuYg4t4NTaxkwYrrocgsJZuYac2ogEdZX", Base58.Prefix.SecretKeyTestnet)._1
     )
 
     val publicKeys = privateKeys.map(_.publicKey)
@@ -50,8 +50,8 @@ class SighashSpec extends FunSuite {
 
   test("SIGHASH_ANYONECANPAY lets you add inputs (SEGWIT version") {
     val privateKeys = List(
-      PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet),
-      PrivateKey.fromBase58("cV5oyXUgySSMcUvKNdKtuYg4t4NTaxkwYrrocgsJZuYac2ogEdZX", Base58.Prefix.SecretKeyTestnet)
+      PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1,
+      PrivateKey.fromBase58("cV5oyXUgySSMcUvKNdKtuYg4t4NTaxkwYrrocgsJZuYac2ogEdZX", Base58.Prefix.SecretKeyTestnet)._1
     )
 
     val publicKeys = privateKeys.map(_.publicKey)

--- a/src/test/scala/fr/acinq/bitcoin/TransactionMalleabilitySpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionMalleabilitySpec.scala
@@ -10,7 +10,7 @@ class TransactionMalleabilitySpec extends FlatSpec {
     val prevTx = Transaction.read("01000000014a1140be18e3affa32a9561a3a4a75b9ed8b965a368a6f39fc57aee97c0eb4df010000006a4730440220363ce2ad434d16d8ca4f35866432fec887526bed328ec705af3a36cef1625fce0220579c0a7c57fe8a3691c833b78de7a3886a5e66422866e5d66cfcede2b8aaaac50121024034a310a6001ea45f7c9708c2f878c8ce42d715ceeaa2cd315af9d97baf85faffffffff02d0f9a800000000001976a91450ca5b3fb8268714ef48b0d46813df337dc5d5db88ac80969800000000001976a914d59dbfeedb94e9e66bd8b91af6caad082971b1b588ac00000000")
 
     // private key that matches the public key the btc we sent to in the tx we want to redeem
-    val privateKey = PrivateKey.fromBase58("cSjAjBx5zSuA16zhG2owyNCzkXLc7qJTz9M8aR6uK9S9QqS9P6gF", Base58.Prefix.SecretKeyTestnet)
+    val privateKey = PrivateKey.fromBase58("cSjAjBx5zSuA16zhG2owyNCzkXLc7qJTz9M8aR6uK9S9QqS9P6gF", Base58.Prefix.SecretKeyTestnet)._1
     //    val (_, privateKey) = Base58Check.decode("cSjAjBx5zSuA16zhG2owyNCzkXLc7qJTz9M8aR6uK9S9QqS9P6gF")
 
     // public key we want to sent btc to

--- a/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
@@ -167,10 +167,6 @@ class TransactionSpec extends FunSuite with Matchers {
       Transaction.read("0100000001345b2a5f872f73de2c4f32e4c28834832ba4c2ce5e54af1e8b897f49766141af00000000fdfe0000483045022100e5a3c850d7cb8776bfbd3fa4b24ce9bb3514fe96a922449dd14c03f5fa04d6ad022035710c6b9c2922c7b8de02fb674cb61e2c18ea439b190b4f55c14fad1ed89eb801483045022100ec6b1ea37cc5694312f7d5fe72280ef21688d11e00f307fdcc1eff30718e30560220542e02c32e3e392cce7adfc287c72f7f1e51ca73980505c2bebcf0b7b441ff90014c6952210394d30868076ab1ea7736ed3bdbec99497a6ad30b25afd709cdf3804cd389996a21032c58bc9615a6ff24e9132cef33f1ef373d97dc6da7933755bc8bb86dbee9f55c2102c4d72d99ca5ad12c17c9cfe043dc4e777075e8835af96f46d8e3ccd929fe192653aeffffffff0100350c00000000001976a914801d5eb10d2c1513ba1960fd8893f0ddbbe33bb388ac00000000")
     )
 
-    val sigdata = List(
-      SignData(previousTx(0).txOut(0).publicKeyScript, PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1),
-      SignData(previousTx(1).txOut(0).publicKeyScript, PrivateKey.fromBase58("93NJN4mhL21FxRbfHZJ2Cou1YnrJmWNkujmZxeT7CPKauJkGv5g", Base58.Prefix.SecretKeyTestnet)._1)
-    )
     val keys = List(
       PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1,
       PrivateKey.fromBase58("93NJN4mhL21FxRbfHZJ2Cou1YnrJmWNkujmZxeT7CPKauJkGv5g", Base58.Prefix.SecretKeyTestnet)._1

--- a/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
@@ -31,8 +31,7 @@ class TransactionSpec extends FunSuite with Matchers {
     // hash code type
     val serialized = ByteVector.view(out.toByteArray)
     val hashed = Crypto.hash256(serialized)
-    val pkey_encoded = ByteVector.fromValidBase58("92f9274aR3s6zd1vuAgxquv4KP5S5thJadF3k54NHuTV4fXL1vW")
-    val pkey = PrivateKey(pkey_encoded.slice(1, pkey_encoded.size - 4))
+    val pkey = PrivateKey.fromBase58("92f9274aR3s6zd1vuAgxquv4KP5S5thJadF3k54NHuTV4fXL1vW", Base58.Prefix.SecretKeyTestnet)
     val sig = Crypto.compact2der(Crypto.sign(hashed, pkey))
     // DER encoded
     val sigOut = new ByteArrayOutputStream()

--- a/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
@@ -39,7 +39,7 @@ class TransactionSpec extends FunSuite with Matchers {
     sigOut.write(sig.toArray)
     writeUInt8(1, sigOut)
     // hash code type
-    val pub = pkey.publicKey.serialize(false)
+    val pub = pkey.publicKey.toUncompressedBin
     writeUInt8(pub.length.toInt, sigOut)
     sigOut.write(pub.toArray)
     val sigScript = sigOut.toByteArray
@@ -189,8 +189,8 @@ class TransactionSpec extends FunSuite with Matchers {
     val sig1 = Transaction.signInput(tx, 0, previousTx(0).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(0))
     val sig2 = Transaction.signInput(tx, 1, previousTx(1).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(1))
     val tx1 = tx
-      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.serialize(true)) :: Nil)
-      .updateSigScript(1, OP_PUSHDATA(sig2) :: OP_PUSHDATA(keys(1).publicKey.serialize(false)) :: Nil)
+      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.toBin) :: Nil)
+      .updateSigScript(1, OP_PUSHDATA(sig2) :: OP_PUSHDATA(keys(1).publicKey.toUncompressedBin) :: Nil)
 
     assert(tx1.toString == "01000000026c8a0bb4fef409509800066578a718e9a771082d94e96e0885a4b6a15b720c02000000006b483045022100e5510a2f15f03788ee2aeb2115edc96089596e3a0f0c1b1abfbbf069f4beedb802203faf6ec92a5a4ed2ce5fd42621be99746b57eca0eb46d322dc076080338b6c5a0121030533e1d2e9b7576fef26de1f34d67887158b7af1b040850aab6024b07925d70affffffffaf01f14881716b8acb062c33e7a66fc71e77bb2e4359b1f91b959aeb4f8837f1000000008b483045022100d3e5756f36e39a801c71c406124b3e0a66f0893a7fea46c69939b84715137c40022070a0e96e37c0a8e8c920e84fc63ed1914b4cef114a027f2d027d0a4a04b0b52d0141040081a4cce4c497d51d2f9be2d2109c00cbdef252185ca23074889604ace3504d73fd5f5aaac6423b04e776e467a948e1e79cb8793ded5f4b59c730c4460a0f86ffffffff02c0c62d00000000001976a914558c6b340f5abd22bf97b15cbc1483f8f1b54f5f88aca0f01900000000001976a914a1f93b5b00f9f5e8ade5549b58ed06cdc5c8203e88ac00000000")
 
@@ -234,7 +234,7 @@ class TransactionSpec extends FunSuite with Matchers {
 
     // and sign it
     val sig = Transaction.signInput(tx, 0, previousTx.txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, privateKey)
-    val signedTx = tx.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(privateKey.publicKey.serialize(false)) :: Nil)
+    val signedTx = tx.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(privateKey.publicKey.toUncompressedBin) :: Nil)
     Transaction.correctlySpends(signedTx, previousTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
     // how to spend our tx ? let's try to sent its output to our public key
@@ -299,9 +299,9 @@ class TransactionSpec extends FunSuite with Matchers {
     val sig3 = Transaction.signInput(tx, 2, previousTx(2).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(2))
 
     val signedTx = tx
-      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.serialize(true)) :: Nil)
-      .updateSigScript(1, OP_PUSHDATA(sig2) :: OP_PUSHDATA(keys(1).publicKey.serialize(false)) :: Nil)
-      .updateSigScript(2, OP_PUSHDATA(sig3) :: OP_PUSHDATA(keys(2).publicKey.serialize(false)) :: Nil)
+      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.toBin) :: Nil)
+      .updateSigScript(1, OP_PUSHDATA(sig2) :: OP_PUSHDATA(keys(1).publicKey.toUncompressedBin) :: Nil)
+      .updateSigScript(2, OP_PUSHDATA(sig3) :: OP_PUSHDATA(keys(2).publicKey.toUncompressedBin) :: Nil)
 
     //this works because signature is not randomized
     assert(signedTx.toString == "0100000003864d5e5ec82c9e6f4ac52b8fa47b77f8616bbc26fcf668432c097c5add169584010000006a47304402203be0cff1faacadce3b02d615a8ac15532f9a90bd30e109eaa3e01bfa3a97d90b0220355f3bc382e35b9cae24e5d674f200b289bb948675ce1b5c931029ccb23ae836012102fd18c2a069488288ae93c2157dff3fd657a39426e8753512a5547f046b4a2cbbffffffffd587b10688e6d56225dd4dc488b74229a353e4613cbe1deadaef52b56616baa9000000008b483045022100ab98145e8526b32e821beeaed41a98da68c3c75ee13c477ee0e3d66a626217e902204d015af2e7dba834bbe421dd0b1353a1060dafee58c284dd763e07639858f9340141043ca81d9fe7996372eb21b2588af07c7fbdb6d4fc1da13aaf953c520ba1da4f87d53dfcba3525369fdb248e60233fdf6df0a8183a6dd5699c9a6f5c537367c627ffffffff94a162b4aab080a09fa982a5d7f586045ba2a4c653c98ff47b952d43c25b45fd000000008a47304402200e0c0223d169282a48731b58ff0673c00205deb3f3f4f28d99b50730ada1571402202fa9f051762d8e0199791ea135df1f393578c1eea530bec00fa16f6bba7e3aa3014104626f9b06c44bcfd5d2f6bdeab456591287e2d2b2e299815edf0c9fd0f23c21364ed5dbe97c9c6e2be40fff40c31f8561a9dee015146fe59ecf68b8a377292c72ffffffff02c0c62d00000000001976a914e410e8bc694e8a39c32a273eb1d71930f63648fe88acc0cf6a00000000001976a914324505870d6f21dca7d2f90642cd9603553f6fa688ac00000000")

--- a/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
@@ -31,7 +31,7 @@ class TransactionSpec extends FunSuite with Matchers {
     // hash code type
     val serialized = ByteVector.view(out.toByteArray)
     val hashed = Crypto.hash256(serialized)
-    val pkey = PrivateKey.fromBase58("92f9274aR3s6zd1vuAgxquv4KP5S5thJadF3k54NHuTV4fXL1vW", Base58.Prefix.SecretKeyTestnet)
+    val pkey = PrivateKey.fromBase58("92f9274aR3s6zd1vuAgxquv4KP5S5thJadF3k54NHuTV4fXL1vW", Base58.Prefix.SecretKeyTestnet)._1
     val sig = Crypto.compact2der(Crypto.sign(hashed, pkey))
     // DER encoded
     val sigOut = new ByteArrayOutputStream()
@@ -39,9 +39,9 @@ class TransactionSpec extends FunSuite with Matchers {
     sigOut.write(sig.toArray)
     writeUInt8(1, sigOut)
     // hash code type
-    val pub = pkey.publicKey
-    writeUInt8(pub.value.length.toInt, sigOut)
-    sigOut.write(pub.toBin.toArray)
+    val pub = pkey.publicKey.serialize(false)
+    writeUInt8(pub.length.toInt, sigOut)
+    sigOut.write(pub.toArray)
     val sigScript = sigOut.toByteArray
 
     val signedOut = new ByteArrayOutputStream()
@@ -66,7 +66,7 @@ class TransactionSpec extends FunSuite with Matchers {
   test("create and verify pay2pk transactions with 1)put/1 output") {
     val to = "mi1cMMSL9BZwTQZYpweE1nTmwRxScirPp3"
     val amount = 10000 satoshi
-    val privateKey = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)
+    val privateKey = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)._1
 
     val previousTx = Transaction.read("0100000001b021a77dcaad3a2da6f1611d2403e1298a902af8567c25d6e65073f6b52ef12d000000006a473044022056156e9f0ad7506621bc1eb963f5133d06d7259e27b13fcb2803f39c7787a81c022056325330585e4be39bcf63af8090a2deff265bc29a3fb9b4bf7a31426d9798150121022dfb538041f111bb16402aa83bd6a3771fa8aa0e5e9b0b549674857fafaf4fe0ffffffff0210270000000000001976a91415c23e7f4f919e9ff554ec585cb2a67df952397488ac3c9d1000000000001976a9148982824e057ccc8d4591982df71aa9220236a63888ac00000000")
     // create a transaction where the sig script is the pubkey script of the tx we want to redeem
@@ -127,7 +127,7 @@ class TransactionSpec extends FunSuite with Matchers {
     val (Base58.Prefix.PubkeyAddressTestnet, pubkeyHash) = Base58Check.decode(to)
     val amount = 10000 satoshi
 
-    val privateKey = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)
+    val privateKey = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)._1
     val publicKey = privateKey.publicKey
 
     val previousTx = Transaction.read("0100000001b021a77dcaad3a2da6f1611d2403e1298a902af8567c25d6e65073f6b52ef12d000000006a473044022056156e9f0ad7506621bc1eb963f5133d06d7259e27b13fcb2803f39c7787a81c022056325330585e4be39bcf63af8090a2deff265bc29a3fb9b4bf7a31426d9798150121022dfb538041f111bb16402aa83bd6a3771fa8aa0e5e9b0b549674857fafaf4fe0ffffffff0210270000000000001976a91415c23e7f4f919e9ff554ec585cb2a67df952397488ac3c9d1000000000001976a9148982824e057ccc8d4591982df71aa9220236a63888ac00000000")
@@ -167,9 +167,13 @@ class TransactionSpec extends FunSuite with Matchers {
       Transaction.read("0100000001345b2a5f872f73de2c4f32e4c28834832ba4c2ce5e54af1e8b897f49766141af00000000fdfe0000483045022100e5a3c850d7cb8776bfbd3fa4b24ce9bb3514fe96a922449dd14c03f5fa04d6ad022035710c6b9c2922c7b8de02fb674cb61e2c18ea439b190b4f55c14fad1ed89eb801483045022100ec6b1ea37cc5694312f7d5fe72280ef21688d11e00f307fdcc1eff30718e30560220542e02c32e3e392cce7adfc287c72f7f1e51ca73980505c2bebcf0b7b441ff90014c6952210394d30868076ab1ea7736ed3bdbec99497a6ad30b25afd709cdf3804cd389996a21032c58bc9615a6ff24e9132cef33f1ef373d97dc6da7933755bc8bb86dbee9f55c2102c4d72d99ca5ad12c17c9cfe043dc4e777075e8835af96f46d8e3ccd929fe192653aeffffffff0100350c00000000001976a914801d5eb10d2c1513ba1960fd8893f0ddbbe33bb388ac00000000")
     )
 
+    val sigdata = List(
+      SignData(previousTx(0).txOut(0).publicKeyScript, PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1),
+      SignData(previousTx(1).txOut(0).publicKeyScript, PrivateKey.fromBase58("93NJN4mhL21FxRbfHZJ2Cou1YnrJmWNkujmZxeT7CPKauJkGv5g", Base58.Prefix.SecretKeyTestnet)._1)
+    )
     val keys = List(
-      SignData(previousTx(0).txOut(0).publicKeyScript, PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)),
-      SignData(previousTx(1).txOut(0).publicKeyScript, PrivateKey.fromBase58("93NJN4mhL21FxRbfHZJ2Cou1YnrJmWNkujmZxeT7CPKauJkGv5g", Base58.Prefix.SecretKeyTestnet))
+      PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1,
+      PrivateKey.fromBase58("93NJN4mhL21FxRbfHZJ2Cou1YnrJmWNkujmZxeT7CPKauJkGv5g", Base58.Prefix.SecretKeyTestnet)._1
     )
 
     // create a tx with empty)put signature scripts
@@ -186,7 +190,12 @@ class TransactionSpec extends FunSuite with Matchers {
       lockTime = 0L
     )
 
-    val tx1 = Transaction.sign(tx, keys)
+    val sig1 = Transaction.signInput(tx, 0, previousTx(0).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(0))
+    val sig2 = Transaction.signInput(tx, 1, previousTx(1).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(1))
+    val tx1 = tx
+      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.serialize(true)) :: Nil)
+      .updateSigScript(1, OP_PUSHDATA(sig2) :: OP_PUSHDATA(keys(1).publicKey.serialize(false)) :: Nil)
+
     assert(tx1.toString == "01000000026c8a0bb4fef409509800066578a718e9a771082d94e96e0885a4b6a15b720c02000000006b483045022100e5510a2f15f03788ee2aeb2115edc96089596e3a0f0c1b1abfbbf069f4beedb802203faf6ec92a5a4ed2ce5fd42621be99746b57eca0eb46d322dc076080338b6c5a0121030533e1d2e9b7576fef26de1f34d67887158b7af1b040850aab6024b07925d70affffffffaf01f14881716b8acb062c33e7a66fc71e77bb2e4359b1f91b959aeb4f8837f1000000008b483045022100d3e5756f36e39a801c71c406124b3e0a66f0893a7fea46c69939b84715137c40022070a0e96e37c0a8e8c920e84fc63ed1914b4cef114a027f2d027d0a4a04b0b52d0141040081a4cce4c497d51d2f9be2d2109c00cbdef252185ca23074889604ace3504d73fd5f5aaac6423b04e776e467a948e1e79cb8793ded5f4b59c730c4460a0f86ffffffff02c0c62d00000000001976a914558c6b340f5abd22bf97b15cbc1483f8f1b54f5f88aca0f01900000000001976a914a1f93b5b00f9f5e8ade5549b58ed06cdc5c8203e88ac00000000")
 
     // now check that we can redeem this tx
@@ -205,7 +214,7 @@ class TransactionSpec extends FunSuite with Matchers {
 
     // we want to spend the first output of this tx
     val previousTx = Transaction.read("01000000014100d6a4d20ff14dfffd772aa3610881d66332ed160fc1094a338490513b0cf800000000fc0047304402201182201b586c6bfe6fd0346382900834149674d3cbb4081c304965440b1c0af20220023b62a997f4385e9279dc1078590556c6c6a85c3ec20fda407e95eb270e4de90147304402200c75f91f8bd741a8e71d11ff6a3e931838e32ceead34ccccfe3f73f01a81e45f02201795881473644b5f5ee6a8d8a90fe16e60eacace40e88900c375af2e0c51e26d014c69522103bd95bfc136869e2e5e3b0491e45c32634b0201a03903e210b01be248e04df8702103e04f714a4010ca5bb1423ef97012cb1008fb0dfd2f02acbcd3650771c46e4a8f2102913bd21425454688bdc2df2f0e518c5f3109b1c1be56e6e783a41c394c95dc0953aeffffffff0140420f00000000001976a914298e5c1e2d2cf22deffd2885394376c7712f9c6088ac00000000")
-    val privateKey = PrivateKey.fromBase58("92TgRLMLLdwJjT1JrrmTTWEpZ8uG7zpHEgSVPTbwfAs27RpdeWM", Base58.Prefix.SecretKeyTestnet)
+    val privateKey = PrivateKey.fromBase58("92TgRLMLLdwJjT1JrrmTTWEpZ8uG7zpHEgSVPTbwfAs27RpdeWM", Base58.Prefix.SecretKeyTestnet)._1
     val publicKey = privateKey.publicKey
 
     // create and serialize a "2 out of 3" multisig script
@@ -229,7 +238,7 @@ class TransactionSpec extends FunSuite with Matchers {
 
     // and sign it
     val sig = Transaction.signInput(tx, 0, previousTx.txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, privateKey)
-    val signedTx = tx.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(privateKey.publicKey) :: Nil)
+    val signedTx = tx.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(privateKey.publicKey.serialize(false)) :: Nil)
     Transaction.correctlySpends(signedTx, previousTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
     // how to spend our tx ? let's try to sent its output to our public key
@@ -257,10 +266,11 @@ class TransactionSpec extends FunSuite with Matchers {
       Transaction.read("0100000001cec6dd9f7ddc640f7bb54daf5623040532b8783472df1de3adc70df9b0f04f05010000006b483045022100d6fb138dca5e6cce925a4bcc322d02ab194f68a0c2794bb1a555dc1ff8c2465f02205a4977af8f398b013da33e61a35f83578c3a9cccea3328b6c982ff4dc8092c7e01210224fc92517bc13b1e9f609054afc2539f2f121f4c1e45fb46fac21364c42440c6ffffffff01400d0300000000001976a9146a3e65bf746bcd7af3493e19451451a8a4da331588ac00000000"),
       Transaction.read("01000000016d1f1a7f8c1307139ef78080ba8442852c6766d3fbb826d2ac0e6fb2f72dd8dc000000008b483045022100bdd23d0f98a4173a64fa432b8bf4ac41261a671f2c6c690d57ac839866d78bb202207bddb87ca95c9cef45de30a75144e5513571aa7938635b9e051b1c20f01088a60141044aec194c55c97f4519535f50f5539c6915045ecb79a36281dee6db55ffe1ad2e55f4a1c0e0950d3511e8f205b45cafa348a4a2ab2359246cb3c93f6532c4e8f5ffffffff0140548900000000001976a914c622640075eaeda95a5ac26fa05a0b894a3def8c88ac00000000")
     )
+
     val keys = List(
-      SignData(previousTx(0).txOut(1).publicKeyScript, PrivateKey.fromBase58("cW6bSKtH3oMPA18cXSMR8ASHztrmbwmCyqvvN8x3Tc7WG6TyrJDg", Base58.Prefix.SecretKeyTestnet)),
-      SignData(previousTx(1).txOut(0).publicKeyScript, PrivateKey.fromBase58("93Ag8t83NW9WmPbhqLCSUNckARpbpgWtp4EWGidtj6h6pVQgGN4", Base58.Prefix.SecretKeyTestnet)),
-      SignData(previousTx(2).txOut(0).publicKeyScript, PrivateKey.fromBase58("921vnTeSQCN7GMHdiHyaoZ1JSugTtzvg8rqyXH9HmFtBgrNDxCT", Base58.Prefix.SecretKeyTestnet))
+      PrivateKey.fromBase58("cW6bSKtH3oMPA18cXSMR8ASHztrmbwmCyqvvN8x3Tc7WG6TyrJDg", Base58.Prefix.SecretKeyTestnet)._1,
+      PrivateKey.fromBase58("93Ag8t83NW9WmPbhqLCSUNckARpbpgWtp4EWGidtj6h6pVQgGN4", Base58.Prefix.SecretKeyTestnet)._1,
+      PrivateKey.fromBase58("921vnTeSQCN7GMHdiHyaoZ1JSugTtzvg8rqyXH9HmFtBgrNDxCT", Base58.Prefix.SecretKeyTestnet)._1
     )
 
     val dest1 = "n2Jrcf7cJH7wMJdhKZGVi2jaSnV2BwYE9m"
@@ -288,7 +298,14 @@ class TransactionSpec extends FunSuite with Matchers {
       lockTime = 0L
     )
 
-    val signedTx = Transaction.sign(tx, keys)
+    val sig1 = Transaction.signInput(tx, 0, previousTx(0).txOut(1).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(0))
+    val sig2 = Transaction.signInput(tx, 1, previousTx(1).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(1))
+    val sig3 = Transaction.signInput(tx, 2, previousTx(2).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(2))
+
+    val signedTx = tx
+      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.serialize(true)) :: Nil)
+      .updateSigScript(1, OP_PUSHDATA(sig2) :: OP_PUSHDATA(keys(1).publicKey.serialize(false)) :: Nil)
+      .updateSigScript(2, OP_PUSHDATA(sig3) :: OP_PUSHDATA(keys(2).publicKey.serialize(false)) :: Nil)
 
     //this works because signature is not randomized
     assert(signedTx.toString == "0100000003864d5e5ec82c9e6f4ac52b8fa47b77f8616bbc26fcf668432c097c5add169584010000006a47304402203be0cff1faacadce3b02d615a8ac15532f9a90bd30e109eaa3e01bfa3a97d90b0220355f3bc382e35b9cae24e5d674f200b289bb948675ce1b5c931029ccb23ae836012102fd18c2a069488288ae93c2157dff3fd657a39426e8753512a5547f046b4a2cbbffffffffd587b10688e6d56225dd4dc488b74229a353e4613cbe1deadaef52b56616baa9000000008b483045022100ab98145e8526b32e821beeaed41a98da68c3c75ee13c477ee0e3d66a626217e902204d015af2e7dba834bbe421dd0b1353a1060dafee58c284dd763e07639858f9340141043ca81d9fe7996372eb21b2588af07c7fbdb6d4fc1da13aaf953c520ba1da4f87d53dfcba3525369fdb248e60233fdf6df0a8183a6dd5699c9a6f5c537367c627ffffffff94a162b4aab080a09fa982a5d7f586045ba2a4c653c98ff47b952d43c25b45fd000000008a47304402200e0c0223d169282a48731b58ff0673c00205deb3f3f4f28d99b50730ada1571402202fa9f051762d8e0199791ea135df1f393578c1eea530bec00fa16f6bba7e3aa3014104626f9b06c44bcfd5d2f6bdeab456591287e2d2b2e299815edf0c9fd0f23c21364ed5dbe97c9c6e2be40fff40c31f8561a9dee015146fe59ecf68b8a377292c72ffffffff02c0c62d00000000001976a914e410e8bc694e8a39c32a273eb1d71930f63648fe88acc0cf6a00000000001976a914324505870d6f21dca7d2f90642cd9603553f6fa688ac00000000")

--- a/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
@@ -189,7 +189,7 @@ class TransactionSpec extends FunSuite with Matchers {
     val sig1 = Transaction.signInput(tx, 0, previousTx(0).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(0))
     val sig2 = Transaction.signInput(tx, 1, previousTx(1).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(1))
     val tx1 = tx
-      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.toBin) :: Nil)
+      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.value) :: Nil)
       .updateSigScript(1, OP_PUSHDATA(sig2) :: OP_PUSHDATA(keys(1).publicKey.toUncompressedBin) :: Nil)
 
     assert(tx1.toString == "01000000026c8a0bb4fef409509800066578a718e9a771082d94e96e0885a4b6a15b720c02000000006b483045022100e5510a2f15f03788ee2aeb2115edc96089596e3a0f0c1b1abfbbf069f4beedb802203faf6ec92a5a4ed2ce5fd42621be99746b57eca0eb46d322dc076080338b6c5a0121030533e1d2e9b7576fef26de1f34d67887158b7af1b040850aab6024b07925d70affffffffaf01f14881716b8acb062c33e7a66fc71e77bb2e4359b1f91b959aeb4f8837f1000000008b483045022100d3e5756f36e39a801c71c406124b3e0a66f0893a7fea46c69939b84715137c40022070a0e96e37c0a8e8c920e84fc63ed1914b4cef114a027f2d027d0a4a04b0b52d0141040081a4cce4c497d51d2f9be2d2109c00cbdef252185ca23074889604ace3504d73fd5f5aaac6423b04e776e467a948e1e79cb8793ded5f4b59c730c4460a0f86ffffffff02c0c62d00000000001976a914558c6b340f5abd22bf97b15cbc1483f8f1b54f5f88aca0f01900000000001976a914a1f93b5b00f9f5e8ade5549b58ed06cdc5c8203e88ac00000000")
@@ -242,7 +242,7 @@ class TransactionSpec extends FunSuite with Matchers {
       txIn = TxIn(OutPoint(signedTx.hash, 0), signatureScript = ByteVector.empty, sequence = 0xFFFFFFFFL) :: Nil,
       txOut = TxOut(
         amount = 900000 satoshi,
-        publicKeyScript = OP_DUP :: OP_HASH160 :: OP_PUSHDATA(Crypto.hash160(publicKey.toBin)) :: OP_EQUALVERIFY :: OP_CHECKSIG :: Nil) :: Nil,
+        publicKeyScript = OP_DUP :: OP_HASH160 :: OP_PUSHDATA(Crypto.hash160(publicKey.value)) :: OP_EQUALVERIFY :: OP_CHECKSIG :: Nil) :: Nil,
       lockTime = 0L)
 
     // we need at least 2 signatures
@@ -299,7 +299,7 @@ class TransactionSpec extends FunSuite with Matchers {
     val sig3 = Transaction.signInput(tx, 2, previousTx(2).txOut(0).publicKeyScript, SIGHASH_ALL, 0 satoshi, SigVersion.SIGVERSION_BASE, keys(2))
 
     val signedTx = tx
-      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.toBin) :: Nil)
+      .updateSigScript(0, OP_PUSHDATA(sig1) :: OP_PUSHDATA(keys(0).publicKey.value) :: Nil)
       .updateSigScript(1, OP_PUSHDATA(sig2) :: OP_PUSHDATA(keys(1).publicKey.toUncompressedBin) :: Nil)
       .updateSigScript(2, OP_PUSHDATA(sig3) :: OP_PUSHDATA(keys(2).publicKey.toUncompressedBin) :: Nil)
 

--- a/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/TransactionSpec.scala
@@ -41,7 +41,7 @@ class TransactionSpec extends FunSuite with Matchers {
     writeUInt8(1, sigOut)
     // hash code type
     val pub = pkey.publicKey
-    writeUInt8(pub.length.toInt, sigOut)
+    writeUInt8(pub.value.length.toInt, sigOut)
     sigOut.write(pub.toBin.toArray)
     val sigScript = sigOut.toByteArray
 

--- a/src/test/scala/fr/acinq/bitcoin/reference/KeyEncodingSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/reference/KeyEncodingSpec.scala
@@ -23,6 +23,8 @@ class KeyEncodingSpec extends FunSuite {
   }
 
   test("invalid keys") {
+    val result = KeyEncodingSpec.isValidBase58("KxuACDviz8Xvpn1xAh9MfopySZNuyajYMZWz16Dv2mHHryznWUp3")
+
     val stream = classOf[KeyEncodingSpec].getResourceAsStream("/data/key_io_invalid.json")
     val json = JsonMethods.parse(new InputStreamReader(stream))
 
@@ -41,7 +43,7 @@ object KeyEncodingSpec {
   def isValidBase58(input: String): Boolean = Try {
     val (prefix, bin) = Base58Check.decode(input)
     prefix match {
-      case Base58.Prefix.SecretKey | Base58.Prefix.SecretKeyTestnet => Try(PrivateKey(bin)).isSuccess
+      case Base58.Prefix.SecretKey | Base58.Prefix.SecretKeyTestnet => Try(PrivateKey.deserialize(bin)).isSuccess
       case Base58.Prefix.PubkeyAddress | Base58.Prefix.PubkeyAddressTestnet => bin.length == 20
       case _ => false
     }

--- a/src/test/scala/fr/acinq/bitcoin/reference/KeyEncodingSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/reference/KeyEncodingSpec.scala
@@ -43,7 +43,7 @@ object KeyEncodingSpec {
   def isValidBase58(input: String): Boolean = Try {
     val (prefix, bin) = Base58Check.decode(input)
     prefix match {
-      case Base58.Prefix.SecretKey | Base58.Prefix.SecretKeyTestnet => Try(PrivateKey.deserialize(bin)).isSuccess
+      case Base58.Prefix.SecretKey | Base58.Prefix.SecretKeyTestnet => Try(PrivateKey.fromBin(bin)).isSuccess
       case Base58.Prefix.PubkeyAddress | Base58.Prefix.PubkeyAddressTestnet => bin.length == 20
       case _ => false
     }


### PR DESCRIPTION
We now always encode EC points in compressed format (i.e x + sign of y), and public keys are implemented as a point and a "compressed" flag. We also make sure that points are not decompressed unless it's explicitly needed (it should never be the case in LN for example).