### PR TITLE
Update to Scala 2.13.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.acinq</groupId>
-    <artifactId>bitcoin-lib_2.11</artifactId>
+    <artifactId>bitcoin-lib_2.13</artifactId>
     <packaging>jar</packaging>
     <version>0.18-SNAPSHOT</version>
     <description>Simple Scala Bitcoin library</description>
@@ -10,8 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.version>2.11.12</scala.version>
-        <scala.version.short>2.11</scala.version.short>
+        <scala.version>2.13.3</scala.version>
+        <scala.version.short>2.13</scala.version.short>
     </properties>
 
     <licenses>
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
                 <configuration>
                     <args>
                         <arg>-deprecation</arg>
@@ -59,10 +59,8 @@
                         <arg>-language:implicitConversions</arg>
                         <arg>-Xfatal-warnings</arg>
                         <arg>-unchecked</arg>
-                        <arg>-Xmax-classfile-name</arg>
-                        <arg>140</arg>
                         <arg>-nobootcp</arg>
-                        <arg>-target:jvm-1.7</arg>
+                        <arg>-target:jvm-1.8</arg>
                     </args>
                     <scalaCompatVersion>${scala.version.short}</scalaCompatVersion>
                 </configuration>
@@ -212,7 +210,7 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-jackson_${scala.version.short}</artifactId>
-            <version>3.5.2</version>
+            <version>3.6.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/scala/fr/acinq/bitcoin/BtcAmount.scala
+++ b/src/main/scala/fr/acinq/bitcoin/BtcAmount.scala
@@ -6,7 +6,7 @@ case class Satoshi(private val underlying: Long) extends BtcAmount with Ordered[
   // @formatter:off
   def +(other: Satoshi) = Satoshi(underlying + other.underlying)
   def -(other: Satoshi) = Satoshi(underlying - other.underlying)
-  def unary_-() = Satoshi(-underlying)
+  def unary_- = Satoshi(-underlying)
   def *(m: Long) = Satoshi(underlying * m)
   def *(m: Double) = Satoshi((underlying * m).toLong)
   def /(d: Long) = Satoshi(underlying / d)
@@ -31,7 +31,7 @@ case class MilliBtc(private val underlying: BigDecimal) extends BtcAmount with O
   // @formatter:off
   def +(other: MilliBtc) = MilliBtc(underlying + other.underlying)
   def -(other: MilliBtc) = MilliBtc(underlying - other.underlying)
-  def unary_-() = MilliBtc(-underlying)
+  def unary_- = MilliBtc(-underlying)
   def *(m: Long) = MilliBtc(underlying * m)
   def *(m: Double) = MilliBtc(underlying * m)
   def /(d: Long) = MilliBtc(underlying / d)
@@ -60,7 +60,7 @@ case class Btc(private val underlying: BigDecimal) extends BtcAmount with Ordere
   // @formatter:off
   def +(other: Btc) = Btc(underlying + other.underlying)
   def -(other: Btc) = Btc(underlying - other.underlying)
-  def unary_-() = Btc(-underlying)
+  def unary_- = Btc(-underlying)
   def *(m: Long) = Btc(underlying * m)
   def *(m: Double) = Btc(underlying * m)
   def /(d: Long) = Btc(underlying / d)

--- a/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
+++ b/src/main/scala/fr/acinq/bitcoin/DeterministicWallet.scala
@@ -34,10 +34,10 @@ object DeterministicWallet {
       def toNumber(value: String): Long = if (value.last == '\'') hardened(value.dropRight(1).toLong) else value.toLong
 
       val path1 = path.stripPrefix("m").stripPrefix("/")
-      if (path1.isEmpty) KeyPath.Root else new KeyPath(path1.split('/').map(toNumber))
+      if (path1.isEmpty) KeyPath.Root else new KeyPath(path1.split('/').map(toNumber).toSeq)
     }
 
-    def childNumberToString(childNumber: Long) = if (isHardened(childNumber)) ((childNumber - hardenedKeyIndex).toString + "'") else childNumber.toString
+    def childNumberToString(childNumber: Long) = if (isHardened(childNumber)) (childNumber - hardenedKeyIndex).toString + "'" else childNumber.toString
   }
 
   implicit def keypath2longseq(input: KeyPath): Seq[Long] = input.path

--- a/src/main/scala/fr/acinq/bitcoin/MnemonicCode.scala
+++ b/src/main/scala/fr/acinq/bitcoin/MnemonicCode.scala
@@ -68,7 +68,7 @@ object MnemonicCode {
     require(check == checksumbits, "invalid checksum")
   }
 
-  def validate(mnemonics: String): Unit = validate(mnemonics.split(" "))
+  def validate(mnemonics: String): Unit = validate(mnemonics.split(" ").toSeq)
 
   /**
     * BIP39 seed derivation
@@ -84,5 +84,5 @@ object MnemonicCode {
     ByteVector.view(keyParams.getKey)
   }
 
-  def toSeed(mnemonics: String, passphrase: String): ByteVector = toSeed(mnemonics.split(" "), passphrase)
+  def toSeed(mnemonics: String, passphrase: String): ByteVector = toSeed(mnemonics.split(" ").toSeq, passphrase)
 }

--- a/src/main/scala/fr/acinq/bitcoin/Protocol.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Protocol.scala
@@ -204,7 +204,7 @@ object Protocol {
     for (_ <- 1L to count) {
       items += reader(input, protocolVersion)
     }
-    items
+    items.toSeq
   }
 
   def readCollection[T](input: InputStream, reader: (InputStream, Long) => T, protocolVersion: Long): Seq[T] = readCollection(input, reader, None, protocolVersion)
@@ -307,7 +307,7 @@ object Message extends BtcSerializer[Message] {
     Message(magic, command, payload)
   }
 
-  override def write(input: Message, out: OutputStream, protocolVersion: Long) = {
+  override def write(input: Message, out: OutputStream, protocolVersion: Long): Unit = {
     writeUInt32(input.magic.toInt, out)
     val buffer = new Array[Byte](12)
     input.command.getBytes("ISO-8859-1").copyToArray(buffer)
@@ -343,7 +343,7 @@ object NetworkAddressWithTimestamp extends BtcSerializer[NetworkAddressWithTimes
     NetworkAddressWithTimestamp(time, services, address, port)
   }
 
-  override def write(input: NetworkAddressWithTimestamp, out: OutputStream, protocolVersion: Long) = {
+  override def write(input: NetworkAddressWithTimestamp, out: OutputStream, protocolVersion: Long): Unit = {
     writeUInt32(input.time.toInt, out)
     writeUInt64(input.services, out)
     input.address match {
@@ -369,7 +369,7 @@ object NetworkAddress extends BtcSerializer[NetworkAddress] {
     NetworkAddress(services, address, port)
   }
 
-  override def write(input: NetworkAddress, out: OutputStream, protocolVersion: Long) = {
+  override def write(input: NetworkAddress, out: OutputStream, protocolVersion: Long): Unit = {
     writeUInt64(input.services, out)
     input.address match {
       case _: Inet4Address => writeBytes(hex"00000000000000000000ffff".toArray, out)
@@ -400,7 +400,7 @@ object Version extends BtcSerializer[Version] {
     Version(version, services, timestamp, addr_recv, addr_from, nonce, user_agent, start_height, relay)
   }
 
-  override def write(input: Version, out: OutputStream, protocolVersion: Long) = {
+  override def write(input: Version, out: OutputStream, protocolVersion: Long): Unit = {
     writeUInt32(input.version.toInt, out)
     writeUInt64(input.services, out)
     writeUInt64(input.timestamp, out)

--- a/src/main/scala/fr/acinq/bitcoin/ScriptElt.scala
+++ b/src/main/scala/fr/acinq/bitcoin/ScriptElt.scala
@@ -262,5 +262,5 @@ object ScriptElt {
   val elt2code: Map[ScriptElt, Int] = code2elt.map(_.swap)
 
   // name -> code
-  val name2code = code2elt.mapValues(_.asInstanceOf[Product].productPrefix.stripPrefix("OP_")).map(_.swap) + ("NOP2" -> 0xb1) + ("NOP3" -> 0xb2)
+  val name2code = code2elt.view.mapValues(_.asInstanceOf[Product].productPrefix.stripPrefix("OP_")).map(_.swap).toMap + ("NOP2" -> 0xb1) + ("NOP3" -> 0xb2)
 }

--- a/src/main/scala/fr/acinq/bitcoin/package.scala
+++ b/src/main/scala/fr/acinq/bitcoin/package.scala
@@ -29,7 +29,7 @@ package object bitcoin {
     // @formatter:off
     override def compare(x: Satoshi, y: Satoshi): Int = x.compare(y)
     override def minus(x: Satoshi, y: Satoshi): Satoshi = x - y
-    override def negate(x: Satoshi): Satoshi = Satoshi(-x.toLong)
+    override def negate(x: Satoshi): Satoshi = -x
     override def plus(x: Satoshi, y: Satoshi): Satoshi = x + y
     override def times(x: Satoshi, y: Satoshi): Satoshi = x * y.toLong
     override def toDouble(x: Satoshi): Double = x.toLong.toDouble

--- a/src/main/scala/fr/acinq/bitcoin/package.scala
+++ b/src/main/scala/fr/acinq/bitcoin/package.scala
@@ -29,14 +29,15 @@ package object bitcoin {
     // @formatter:off
     override def compare(x: Satoshi, y: Satoshi): Int = x.compare(y)
     override def minus(x: Satoshi, y: Satoshi): Satoshi = x - y
-    override def negate(x: Satoshi): Satoshi = -x
+    override def negate(x: Satoshi): Satoshi = Satoshi(-x.toLong)
     override def plus(x: Satoshi, y: Satoshi): Satoshi = x + y
     override def times(x: Satoshi, y: Satoshi): Satoshi = x * y.toLong
-    override def toDouble(x: Satoshi): Double = x.toLong
-    override def toFloat(x: Satoshi): Float = x.toLong
+    override def toDouble(x: Satoshi): Double = x.toLong.toDouble
+    override def toFloat(x: Satoshi): Float = x.toLong.toFloat
     override def toInt(x: Satoshi): Int = x.toLong.toInt
     override def toLong(x: Satoshi): Long = x.toLong
     override def fromInt(x: Int): Satoshi = Satoshi(x)
+    override def parseString(str: String): Option[Satoshi] = None
     // @formatter:on
   }
 
@@ -111,6 +112,7 @@ package object bitcoin {
     chainHash match {
       case Block.RegtestGenesisBlock.hash | Block.TestnetGenesisBlock.hash => Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, hash)
       case Block.LivenetGenesisBlock.hash => Base58Check.encode(Base58.Prefix.PubkeyAddress, hash)
+      case _ => throw new IllegalArgumentException("Unknown chain hash: " + chainHash)
     }
   }
 

--- a/src/test/scala/fr/acinq/bitcoin/BIP49Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BIP49Spec.scala
@@ -11,7 +11,7 @@ import scodec.bits._
   */
 class BIP49Spec extends FunSuite {
   test("BIP49 reference tests") {
-    val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ").toSeq, "")
+    val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "")
     val master = DeterministicWallet.generate(seed)
     assert(DeterministicWallet.encode(master, DeterministicWallet.tprv) == "tprv8ZgxMBicQKsPe5YMU9gHen4Ez3ApihUfykaqUorj9t6FDqy3nP6eoXiAo2ssvpAjoLroQxHqr3R5nE3a5dU3DHTjTgJDd7zrbniJr6nrCzd")
 

--- a/src/test/scala/fr/acinq/bitcoin/BIP49Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BIP49Spec.scala
@@ -11,7 +11,7 @@ import scodec.bits._
   */
 class BIP49Spec extends FunSuite {
   test("BIP49 reference tests") {
-    val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" "), "")
+    val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ").toSeq, "")
     val master = DeterministicWallet.generate(seed)
     assert(DeterministicWallet.encode(master, DeterministicWallet.tprv) == "tprv8ZgxMBicQKsPe5YMU9gHen4Ez3ApihUfykaqUorj9t6FDqy3nP6eoXiAo2ssvpAjoLroQxHqr3R5nE3a5dU3DHTjTgJDd7zrbniJr6nrCzd")
 

--- a/src/test/scala/fr/acinq/bitcoin/BIP84Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BIP84Spec.scala
@@ -11,7 +11,7 @@ import scodec.bits._
   */
 class BIP84Spec extends FunSuite {
   test("BIP49 reference tests") {
-    val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ").toSeq, "")
+    val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "")
     val master = DeterministicWallet.generate(seed)
     assert(DeterministicWallet.encode(master, DeterministicWallet.zprv) == "zprvAWgYBBk7JR8Gjrh4UJQ2uJdG1r3WNRRfURiABBE3RvMXYSrRJL62XuezvGdPvG6GFBZduosCc1YP5wixPox7zhZLfiUm8aunE96BBa4Kei5")
     assert(DeterministicWallet.encode(DeterministicWallet.publicKey(master), DeterministicWallet.zpub) == "zpub6jftahH18ngZxLmXaKw3GSZzZsszmt9WqedkyZdezFtWRFBZqsQH5hyUmb4pCEeZGmVfQuP5bedXTB8is6fTv19U1GQRyQUKQGUTzyHACMF")

--- a/src/test/scala/fr/acinq/bitcoin/BIP84Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BIP84Spec.scala
@@ -11,7 +11,7 @@ import scodec.bits._
   */
 class BIP84Spec extends FunSuite {
   test("BIP49 reference tests") {
-    val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" "), "")
+    val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about".split(" ").toSeq, "")
     val master = DeterministicWallet.generate(seed)
     assert(DeterministicWallet.encode(master, DeterministicWallet.zprv) == "zprvAWgYBBk7JR8Gjrh4UJQ2uJdG1r3WNRRfURiABBE3RvMXYSrRJL62XuezvGdPvG6GFBZduosCc1YP5wixPox7zhZLfiUm8aunE96BBa4Kei5")
     assert(DeterministicWallet.encode(DeterministicWallet.publicKey(master), DeterministicWallet.zpub) == "zpub6jftahH18ngZxLmXaKw3GSZzZsszmt9WqedkyZdezFtWRFBZqsQH5hyUmb4pCEeZGmVfQuP5bedXTB8is6fTv19U1GQRyQUKQGUTzyHACMF")

--- a/src/test/scala/fr/acinq/bitcoin/BtcAmountSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BtcAmountSpec.scala
@@ -68,9 +68,9 @@ class BtcAmountSpec extends FunSuite {
   }
 
   test("negate amount") {
-    assert(Satoshi(-20) === -Satoshi(20))
-    assert(MilliBtc(-1.5) === -MilliBtc(1.5))
-    assert(Btc(-2.5) === -Btc(2.5))
+    assert(Satoshi(-20) === Satoshi(20).unary_-())
+    assert(MilliBtc(-1.5) === MilliBtc(1.5).unary_-())
+    assert(Btc(-2.5) === Btc(2.5).unary_-())
   }
 
   test("max/min") {

--- a/src/test/scala/fr/acinq/bitcoin/BtcAmountSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BtcAmountSpec.scala
@@ -68,9 +68,9 @@ class BtcAmountSpec extends FunSuite {
   }
 
   test("negate amount") {
-    assert(Satoshi(-20) === Satoshi(20).unary_-())
-    assert(MilliBtc(-1.5) === MilliBtc(1.5).unary_-())
-    assert(Btc(-2.5) === Btc(2.5).unary_-())
+    assert(Satoshi(-20) === -Satoshi(20))
+    assert(MilliBtc(-1.5) === -MilliBtc(1.5))
+    assert(Btc(-2.5) === -Btc(2.5))
   }
 
   test("max/min") {

--- a/src/test/scala/fr/acinq/bitcoin/samples/FindMyAddresses.scala
+++ b/src/test/scala/fr/acinq/bitcoin/samples/FindMyAddresses.scala
@@ -18,7 +18,7 @@ object FindMyAddresses extends App {
   def address(pub: PublicKey): String = Base58Check.encode(if (testnet) Base58.Prefix.ScriptAddressTestnet else Base58.Prefix.ScriptAddress, Crypto.hash160(Script.write(Script.pay2wpkh(pub))))
 
   // step #1: compute the seed from the mnemonic code
-  val seed = MnemonicCode.toSeed(mnemonics.split(' '), passphrase)
+  val seed = MnemonicCode.toSeed(mnemonics.split(' ').toSeq, passphrase)
 
   // step #2: generate the master key from the seed
   val master = generate(seed)

--- a/src/test/scala/fr/acinq/bitcoin/samples/FindMyAddresses.scala
+++ b/src/test/scala/fr/acinq/bitcoin/samples/FindMyAddresses.scala
@@ -18,7 +18,7 @@ object FindMyAddresses extends App {
   def address(pub: PublicKey): String = Base58Check.encode(if (testnet) Base58.Prefix.ScriptAddressTestnet else Base58.Prefix.ScriptAddress, Crypto.hash160(Script.write(Script.pay2wpkh(pub))))
 
   // step #1: compute the seed from the mnemonic code
-  val seed = MnemonicCode.toSeed(mnemonics.split(' ').toSeq, passphrase)
+  val seed = MnemonicCode.toSeed(mnemonics, passphrase)
 
   // step #2: generate the master key from the seed
   val master = generate(seed)


### PR DESCRIPTION
And fix deprecation warnings.
Since eclair has updated to this version of Scala, bitcoin-lib should follow.