### PR TITLE
Add support for Bech32m (BIP 350)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a simple scala library which implements most of the bitcoin protocol:
 * BIP 39 (mnemonic code for generating deterministic keys)
 * BIP 173 (Base32 address format for native v0-16 witness outputs)
 * BIP 174 (Partially Signed Bitcoin Transaction Format)
+* BIP 350 (Bech32m format)
 
 ## Objectives
 

--- a/src/main/scala/fr/acinq/bitcoin/Bech32.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Bech32.scala
@@ -3,10 +3,17 @@ package fr.acinq.bitcoin
 import scodec.bits.ByteVector
 
 /**
- * See https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+ * Bech32 and Bech32m address formats.
+ * See https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki and https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki.
  */
 object Bech32 {
   val alphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+  // @formatter:off
+  sealed trait Encoding
+  case object Bech32Encoding extends Encoding
+  case object Bech32mEncoding extends Encoding
+  // @formatter:on
 
   // 5 bits integer
   // Bech32 works with 5 bits values, we use this type to make it explicit: whenever you see Int5 it means 5 bits values,
@@ -55,12 +62,23 @@ object Bech32 {
   }
 
   /**
-   * decodes a bech32 string
-   *
-   * @param bech32 bech32 string
-   * @return a (hrp, data) tuple
+   * @param hrp   human readable prefix
+   * @param int5s 5-bit data
+   * @return hrp + data encoded as a Bech32 string
    */
-  def decode(bech32: String): (String, Array[Int5]) = {
+  def encode(hrp: String, int5s: Array[Int5], encoding: Encoding): String = {
+    require(hrp.toLowerCase == hrp || hrp.toUpperCase == hrp, "mixed case strings are not valid bech32 prefixes")
+    val checksum = Bech32.checksum(hrp, int5s, encoding)
+    hrp + "1" + new String((int5s ++ checksum).map(i => alphabet(i)))
+  }
+
+  /**
+   * decodes a bech32 or bech32m string
+   *
+   * @param bech32 bech32 or bech32m string
+   * @return a (encoding, hrp, data) tuple
+   */
+  def decode(bech32: String): (String, Array[Int5], Encoding) = {
     require(bech32.toLowerCase == bech32 || bech32.toUpperCase == bech32, "mixed case strings are not valid bech32")
     bech32.foreach(c => require(c >= 33 && c <= 126, "invalid character"))
     val input = bech32.toLowerCase()
@@ -74,18 +92,27 @@ object Bech32 {
       data(i) = elt
     }
     val checksum = polymod(expand(hrp), data)
-    require(checksum == 1, s"invalid checksum for $bech32")
-    (hrp, data.dropRight(6))
+    val encoding = checksum match {
+      case 1 => Bech32Encoding
+      case 0x2bc830a3 => Bech32mEncoding
+      case _ => throw new IllegalArgumentException(s"invalid checksum for $bech32")
+    }
+    (hrp, data.dropRight(6), encoding)
   }
 
   /**
-   * @param hrp  Human Readable Part
-   * @param data data (a sequence of 5 bits integers)
+   * @param hrp      Human Readable Part
+   * @param data     data (a sequence of 5 bits integers)
+   * @param encoding encoding to use (bech32 or bech32m)
    * @return a checksum computed over hrp and data
    */
-  private def checksum(hrp: String, data: Array[Int5]): Array[Int5] = {
+  private def checksum(hrp: String, data: Array[Int5], encoding: Encoding): Array[Int5] = {
+    val constant = encoding match {
+      case Bech32Encoding => 1
+      case Bech32mEncoding => 0x2bc830a3
+    }
     val values = expand(hrp) ++ data
-    val poly = polymod(values, Array(0.toByte, 0.toByte, 0.toByte, 0.toByte, 0.toByte, 0.toByte)) ^ 1.toByte
+    val poly = polymod(values, Array(0.toByte, 0.toByte, 0.toByte, 0.toByte, 0.toByte, 0.toByte)) ^ constant
     val result = new Array[Int5](6)
     for (i <- 0 to 5) result(i) = ((poly >>> 5 * (5 - i)) & 31).toByte
     result
@@ -136,14 +163,18 @@ object Bech32 {
    * encode a bitcoin witness address
    *
    * @param hrp            should be "bc" or "tb"
-   * @param witnessVersion witness version (0 to 16, only 0 is currently defined)
+   * @param witnessVersion witness version (0 to 16)
    * @param data           witness program: if version is 0, either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
    * @return a bech32 encoded witness address
    */
   def encodeWitnessAddress(hrp: String, witnessVersion: Byte, data: ByteVector): String = {
-    // prepend witness version: 0
+    require(0 <= witnessVersion && witnessVersion <= 16, "invalid segwit version")
+    val encoding = witnessVersion match {
+      case 0 => Bech32Encoding
+      case _ => Bech32mEncoding
+    }
     val data1 = witnessVersion +: Bech32.eight2five(data.toArray)
-    val checksum = Bech32.checksum(hrp, data1)
+    val checksum = Bech32.checksum(hrp, data1, encoding)
     hrp + "1" + new String((data1 ++ checksum).map(i => alphabet(i)))
   }
 
@@ -153,28 +184,20 @@ object Bech32 {
    * @param address witness address
    * @return a (prefix, version, program) tuple where prefix is the human-readable prefix, version
    *         is the witness version and program the decoded witness program.
-   *         If version is 0, it will be either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
+   *         If version is 0, it will be either 20 bytes (P2WPKH) or 32 bytes (P2WSH).
    */
   def decodeWitnessAddress(address: String): (String, Byte, ByteVector) = {
     if (address.indexWhere(_.isLower) != -1 && address.indexWhere(_.isUpper) != -1) throw new IllegalArgumentException("input mixes lowercase and uppercase characters")
-    val (hrp, data) = decode(address)
+    val (hrp, data, encoding) = decode(address)
     require(hrp == "bc" || hrp == "tb" || hrp == "bcrt", s"invalid HRP $hrp")
     val version = data(0)
     require(version >= 0 && version <= 16, "invalid segwit version")
     val bin = five2eight(data.drop(1))
     require(bin.length >= 2 && bin.length <= 40, s"invalid witness program length ${bin.length}")
+    if (version == 0) require(encoding == Bech32Encoding, "version 0 must be encoded with Bech32")
     if (version == 0) require(bin.length == 20 || bin.length == 32, s"invalid witness program length ${bin.length}")
+    if (version != 0) require(encoding == Bech32mEncoding, "version 1 to 16 must be encoded with Bech32m")
     (hrp, version, ByteVector.view(bin))
   }
 
-  /**
-   * @param hrp   human readable prefix
-   * @param int5s 5-bit data
-   * @return hrp + data encoded as a Bech32 string
-   */
-  def encode(hrp: String, int5s: Array[Int5]): String = {
-    require(hrp.toLowerCase == hrp || hrp.toUpperCase == hrp, "mixed case strings are not valid bech32 prefixes")
-    val checksum = Bech32.checksum(hrp, int5s)
-    hrp + "1" + new String((int5s ++ checksum).map(i => alphabet(i)))
-  }
 }

--- a/src/main/scala/fr/acinq/bitcoin/Bech32.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Bech32.scala
@@ -3,25 +3,24 @@ package fr.acinq.bitcoin
 import scodec.bits.ByteVector
 
 /**
-  * See https://github.com/sipa/bech32/blob/master/bip-witaddr.mediawiki
-  */
+ * See https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+ */
 object Bech32 {
   val alphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
   // 5 bits integer
-  // Bech32 works with 5bits values, we use this type to make it explicit: whenever you see Int5 it means 5bits values, and
-  // whenever you see Byte it means 8bits values
+  // Bech32 works with 5 bits values, we use this type to make it explicit: whenever you see Int5 it means 5 bits values,
+  // and whenever you see Byte it means 8 bits values
   type Int5 = Byte
 
   // char -> 5 bits value
   private val InvalidChar = 255.toByte
   val map = {
     val result = new Array[Int5](255)
-    for (i <- 0 until result.length) result(i) = InvalidChar
+    for (i <- result.indices) result(i) = InvalidChar
     alphabet.zipWithIndex.foreach { case (c, i) => result(c) = i.toByte }
     result
   }
-
 
   private def expand(hrp: String): Array[Int5] = {
     val result = new Array[Int5](2 * hrp.length + 1)
@@ -56,20 +55,20 @@ object Bech32 {
   }
 
   /**
-    * decodes a bech32 string
-    *
-    * @param bech32 bech32 string
-    * @return a (hrp, data) tuple
-    */
+   * decodes a bech32 string
+   *
+   * @param bech32 bech32 string
+   * @return a (hrp, data) tuple
+   */
   def decode(bech32: String): (String, Array[Int5]) = {
     require(bech32.toLowerCase == bech32 || bech32.toUpperCase == bech32, "mixed case strings are not valid bech32")
     bech32.foreach(c => require(c >= 33 && c <= 126, "invalid character"))
     val input = bech32.toLowerCase()
     val pos = input.lastIndexOf('1')
     val hrp = input.take(pos)
-    require(hrp.size >= 1 && hrp.size <= 83, "hrp must contain 1 to 83 characters")
+    require(hrp.nonEmpty && hrp.length <= 83, "hrp must contain 1 to 83 characters")
     val data = new Array[Int5](input.length - pos - 1)
-    for (i <- 0 until data.size) {
+    for (i <- data.indices) {
       val elt = map(input(pos + 1 + i))
       require(elt != InvalidChar, s"invalid bech32 character ${input(pos + 1 + i)}")
       data(i) = elt
@@ -80,11 +79,10 @@ object Bech32 {
   }
 
   /**
-    *
-    * @param hrp  Human Readable Part
-    * @param data data (a sequence of 5 bits integers)
-    * @return a checksum computed over hrp and data
-    */
+   * @param hrp  Human Readable Part
+   * @param data data (a sequence of 5 bits integers)
+   * @return a checksum computed over hrp and data
+   */
   private def checksum(hrp: String, data: Array[Int5]): Array[Int5] = {
     val values = expand(hrp) ++ data
     val poly = polymod(values, Array(0.toByte, 0.toByte, 0.toByte, 0.toByte, 0.toByte, 0.toByte)) ^ 1.toByte
@@ -94,10 +92,9 @@ object Bech32 {
   }
 
   /**
-    *
-    * @param input a sequence of 8 bits integers
-    * @return a sequence of 5 bits integers
-    */
+   * @param input a sequence of 8 bits integers
+   * @return a sequence of 5 bits integers
+   */
   def eight2five(input: Array[Byte]): Array[Int5] = {
     var buffer = 0L
     val output = collection.mutable.ArrayBuffer.empty[Byte]
@@ -115,10 +112,9 @@ object Bech32 {
   }
 
   /**
-    *
-    * @param input a sequence of 5 bits integers
-    * @return a sequence of 8 bits integers
-    */
+   * @param input a sequence of 5 bits integers
+   * @return a sequence of 8 bits integers
+   */
   def five2eight(input: Array[Int5]): Array[Byte] = {
     var buffer = 0L
     val output = collection.mutable.ArrayBuffer.empty[Byte]
@@ -137,13 +133,13 @@ object Bech32 {
   }
 
   /**
-    * encode a bitcoin witness address
-    *
-    * @param hrp            should be "bc" or "tb"
-    * @param witnessVersion witness version (0 to 16, only 0 is currently defined)
-    * @param data           witness program: if version is 0, either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
-    * @return a bech32 encoded witness address
-    */
+   * encode a bitcoin witness address
+   *
+   * @param hrp            should be "bc" or "tb"
+   * @param witnessVersion witness version (0 to 16, only 0 is currently defined)
+   * @param data           witness program: if version is 0, either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
+   * @return a bech32 encoded witness address
+   */
   def encodeWitnessAddress(hrp: String, witnessVersion: Byte, data: ByteVector): String = {
     // prepend witness version: 0
     val data1 = witnessVersion +: Bech32.eight2five(data.toArray)
@@ -152,13 +148,13 @@ object Bech32 {
   }
 
   /**
-    * decode a bitcoin witness address
-    *
-    * @param address witness address
-    * @return a (prefix, version, program) tuple where prefix is the human-readble prefix, version
-    *         is the witness version and program the decoded witness program.
-    *         If version is 0, it will be either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
-    */
+   * decode a bitcoin witness address
+   *
+   * @param address witness address
+   * @return a (prefix, version, program) tuple where prefix is the human-readable prefix, version
+   *         is the witness version and program the decoded witness program.
+   *         If version is 0, it will be either 20 bytes (P2WPKH) or 32 bytes (P2WSH)
+   */
   def decodeWitnessAddress(address: String): (String, Byte, ByteVector) = {
     if (address.indexWhere(_.isLower) != -1 && address.indexWhere(_.isUpper) != -1) throw new IllegalArgumentException("input mixes lowercase and uppercase characters")
     val (hrp, data) = decode(address)
@@ -172,11 +168,10 @@ object Bech32 {
   }
 
   /**
-    *
-    * @param hrp   human readable prefix
-    * @param int5s 5-bit data
-    * @return hrp + data encoded as a Bech32 string
-    */
+   * @param hrp   human readable prefix
+   * @param int5s 5-bit data
+   * @return hrp + data encoded as a Bech32 string
+   */
   def encode(hrp: String, int5s: Array[Int5]): String = {
     require(hrp.toLowerCase == hrp || hrp.toUpperCase == hrp, "mixed case strings are not valid bech32 prefixes")
     val checksum = Bech32.checksum(hrp, int5s)

--- a/src/main/scala/fr/acinq/bitcoin/Script.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Script.scala
@@ -1,10 +1,9 @@
 package fr.acinq.bitcoin
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
-
 import fr.acinq.bitcoin.Crypto._
 import scodec.bits.ByteVector
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
@@ -177,7 +176,7 @@ object Script {
     case OP_PUSHDATA(data, 0x4c) :: tail if data.length < 0xff => writeUInt8(0x4c, out); writeUInt8(data.length.toInt, out); out.write(data.toArray); write(tail, out)
     case OP_PUSHDATA(data, 0x4d) :: tail if data.length < 0xffff => writeUInt8(0x4d, out); writeUInt16(data.length.toInt, out); out.write(data.toArray); write(tail, out)
     case OP_PUSHDATA(data, 0x4e) :: tail if data.length < 0xffffffff => writeUInt8(0x4e, out); writeUInt32(data.length, out); out.write(data.toArray); write(tail, out)
-    case op@OP_PUSHDATA(data, code) :: tail => throw new RuntimeException(s"invalid element $op")
+    case op@OP_PUSHDATA(_, _) :: _ => throw new RuntimeException(s"invalid element $op")
     case head :: tail => out.write(elt2code(head)); write(tail, out)
   }
 
@@ -479,7 +478,6 @@ object Script {
     /**
      * execute a script, starting from an empty stack
      *
-     * @param script
      * @return the stack created by the script
      */
     def run(script: List[ScriptElt]): Stack = run(script, List.empty[ByteVector])
@@ -586,7 +584,7 @@ object Script {
             run(tail, encodeNumber(result) :: stacktail, state.copy(opCount = opCount + 1), signatureVersion)
           case _ => throw new RuntimeException("cannot run OP_BOOLOR on a stack with less than 2 elements")
         }
-        case OP_CHECKLOCKTIMEVERIFY :: tail if ((scriptFlag & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY) != 0) => stack match {
+        case OP_CHECKLOCKTIMEVERIFY :: tail if (scriptFlag & SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY) != 0 => stack match {
           case head :: _ =>
             // Note that elsewhere numeric opcodes are limited to
             // operands in the range -2**31+1 to 2**31-1, however it is
@@ -609,9 +607,9 @@ object Script {
             run(tail, stack, state.copy(opCount = opCount + 1), signatureVersion)
           case _ => throw new RuntimeException("cannot run OP_CHECKLOCKTIMEVERIFY on an empty stack")
         }
-        case OP_CHECKLOCKTIMEVERIFY :: _ if ((scriptFlag & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) != 0) => throw new RuntimeException("use of upgradable NOP is discouraged")
+        case OP_CHECKLOCKTIMEVERIFY :: _ if (scriptFlag & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) != 0 => throw new RuntimeException("use of upgradable NOP is discouraged")
         case OP_CHECKLOCKTIMEVERIFY :: tail => run(tail, stack, state.copy(opCount = opCount + 1), signatureVersion)
-        case OP_CHECKSEQUENCEVERIFY :: tail if ((scriptFlag & SCRIPT_VERIFY_CHECKSEQUENCEVERIFY) != 0) => stack match {
+        case OP_CHECKSEQUENCEVERIFY :: tail if (scriptFlag & SCRIPT_VERIFY_CHECKSEQUENCEVERIFY) != 0 => stack match {
           case head :: _ =>
             // nSequence, like nLockTime, is a 32-bit unsigned integer
             // field. See the comment in CHECKLOCKTIMEVERIFY regarding
@@ -635,10 +633,10 @@ object Script {
             run(tail, stack, state.copy(opCount = opCount + 1), signatureVersion)
           case _ => throw new RuntimeException("cannot run OP_CHECKSEQUENCEVERIFY on an empty stack")
         }
-        case OP_CHECKSEQUENCEVERIFY :: _ if ((scriptFlag & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) != 0) => throw new RuntimeException("use of upgradable NOP is discouraged")
+        case OP_CHECKSEQUENCEVERIFY :: _ if (scriptFlag & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) != 0 => throw new RuntimeException("use of upgradable NOP is discouraged")
         case OP_CHECKSEQUENCEVERIFY :: tail => run(tail, stack, state.copy(opCount = opCount + 1), signatureVersion)
         case OP_CHECKSIG :: tail => stack match {
-          case pubKey :: sigBytes :: stacktail => {
+          case pubKey :: sigBytes :: stacktail =>
             // remove signature from script
             val scriptCode1 = if (signatureVersion == SigVersion.SIGVERSION_BASE) {
               val scriptCode1 = removeSignature(scriptCode, sigBytes)
@@ -651,11 +649,10 @@ object Script {
               require(sigBytes.isEmpty, "Signature must be zero for failed CHECKSIG operation")
             }
             run(tail, (if (success) True else False) :: stacktail, state.copy(opCount = opCount + 1), signatureVersion)
-          }
           case _ => throw new RuntimeException("Cannot perform OP_CHECKSIG on a stack with less than 2 elements")
         }
         case OP_CHECKSIGVERIFY :: tail => run(OP_CHECKSIG :: OP_VERIFY :: tail, stack, state.copy(opCount = opCount - 1), signatureVersion)
-        case OP_CHECKMULTISIG :: tail => {
+        case OP_CHECKMULTISIG :: tail =>
           // pop public keys
           val m = decodeNumber(stack.head).toInt
           if (m < 0 || m > 20) throw new RuntimeException("OP_CHECKMULTISIG: invalid number of public keys")
@@ -687,7 +684,6 @@ object Script {
             sigs.foreach(sig => require(sig.isEmpty, "Signature must be zero for failed CHECKMULTISIG operation"))
           }
           run(tail, (if (success) True else False) :: stack4, state.copy(opCount = nextOpCount), signatureVersion)
-        }
         case OP_CHECKMULTISIGVERIFY :: tail => run(OP_CHECKMULTISIG :: OP_VERIFY :: tail, stack, state.copy(opCount = opCount - 1), signatureVersion)
         case OP_CODESEPARATOR :: tail => run(tail, stack, state.copy(opCount = opCount + 1, scriptCode = tail), signatureVersion)
         case OP_DEPTH :: tail => run(tail, encodeNumber(stack.length) :: stack, state.copy(opCount = opCount + 1), signatureVersion)
@@ -804,9 +800,7 @@ object Script {
             run(tail, stacktail(n) :: stacktail, state.copy(opCount = opCount + 1), signatureVersion)
           case _ => throw new RuntimeException("Cannot perform OP_PICK on a stack with less than 1 elements")
         }
-        case OP_PUSHDATA(data, code) :: _ if ((scriptFlag & SCRIPT_VERIFY_MINIMALDATA) != 0) && !OP_PUSHDATA.isMinimal(data, code) => {
-          throw new RuntimeException("not minimal push")
-        }
+        case OP_PUSHDATA(data, code) :: _ if ((scriptFlag & SCRIPT_VERIFY_MINIMALDATA) != 0) && !OP_PUSHDATA.isMinimal(data, code) => throw new RuntimeException("not minimal push")
         case OP_PUSHDATA(data, _) :: tail => run(tail, data :: stack, state, signatureVersion)
         case OP_ROLL :: tail => stack match {
           case head :: stacktail =>
@@ -876,7 +870,7 @@ object Script {
         case 0 =>
           throw new IllegalArgumentException(s"Invalid witness program length: ${program.length}")
         case _ if (scriptFlag & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM) != 0 =>
-          throw new IllegalArgumentException(s"Invalid witness version: ${witnessVersion}")
+          throw new IllegalArgumentException(s"Invalid witness version: $witnessVersion")
         case _ =>
           // Higher version witness scripts return true for future softfork compatibility
           return
@@ -932,13 +926,12 @@ object Script {
       var hadWitness = false
       val stack1 = if ((scriptFlag & SCRIPT_VERIFY_WITNESS) != 0) {
         spub match {
-          case op :: OP_PUSHDATA(program, code) :: Nil if isSimpleValue(op) && OP_PUSHDATA.isMinimal(program, code) && program.length >= 2 && program.length <= 40 => {
+          case op :: OP_PUSHDATA(program, code) :: Nil if isSimpleValue(op) && OP_PUSHDATA.isMinimal(program, code) && program.length >= 2 && program.length <= 40 =>
             hadWitness = true
             val witnessVersion = simpleValue(op)
             require(ssig.isEmpty, "Malleated segwit script")
             verifyWitnessProgram(witness, witnessVersion, program)
             stack0.take(1)
-          }
           case _ => stack0
         }
       } else stack0
@@ -959,13 +952,12 @@ object Script {
 
         if ((scriptFlag & SCRIPT_VERIFY_WITNESS) != 0) {
           Script.parse(stack.head) match {
-            case op :: OP_PUSHDATA(program, _) :: Nil if isSimpleValue(op) && program.length >= 2 && program.length <= 32 => {
+            case op :: OP_PUSHDATA(program, _) :: Nil if isSimpleValue(op) && program.length >= 2 && program.length <= 32 =>
               hadWitness = true
               val witnessVersion = simpleValue(op)
               //require(ssig.isEmpty, "Malleated segwit script")
               verifyWitnessProgram(witness, witnessVersion, program)
               stackp2sh.take(1)
-            }
             case _ => stackp2sh
           }
         } else stackp2sh

--- a/src/main/scala/fr/acinq/bitcoin/package.scala
+++ b/src/main/scala/fr/acinq/bitcoin/package.scala
@@ -1,20 +1,21 @@
 package fr.acinq
 
+import fr.acinq.bitcoin.Crypto.PublicKey
+import scodec.bits.ByteVector
+
 import java.math.BigInteger
 
-import fr.acinq.bitcoin.Crypto.PublicKey
-
 /**
-  * see https://en.bitcoin.it/wiki/Protocol_specification
-  */
+ * see https://en.bitcoin.it/wiki/Protocol_specification
+ */
 package object bitcoin {
   val MaxScriptElementSize = 520
   val MaxBlockSize = 1000000
   val LockTimeThreshold = 500000000L
 
   /**
-    * signature hash flags
-    */
+   * signature hash flags
+   */
   val SIGHASH_ALL = 1
   val SIGHASH_NONE = 2
   val SIGHASH_SINGLE = 3
@@ -63,10 +64,9 @@ package object bitcoin {
   // @formatter:on
 
   /**
-    *
-    * @param input compact size encoded integer as used to encode proof-of-work difficulty target
-    * @return a (result, isNegative, overflow) tuple were result is the decoded integer
-    */
+   * @param input compact size encoded integer as used to encode proof-of-work difficulty target
+   * @return a (result, isNegative, overflow) tuple were result is the decoded integer
+   */
   def decodeCompact(input: Long): (BigInteger, Boolean, Boolean) = {
     val nSize = (input >> 24).toInt
     val (nWord, result) = if (nSize <= 3) {
@@ -82,11 +82,10 @@ package object bitcoin {
   }
 
   /**
-    *
-    * @param value input value
-    * @return the compact encoding of the input value. this is used to encode proof-of-work target into the `bits`
-    *         block header field
-    */
+   * @param value input value
+   * @return the compact encoding of the input value. this is used to encode proof-of-work target into the `bits`
+   *         block header field
+   */
   def encodeCompact(value: BigInteger): Long = {
     var size = value.toByteArray.length
     var compact = if (size <= 3) value.longValue << 8 * (3 - size) else value.shiftRight(8 * (size - 3)).longValue
@@ -116,14 +115,13 @@ package object bitcoin {
     }
   }
 
-  def computeBIP44Address(pub: PublicKey, chainHash: ByteVector32) = computeP2PkhAddress(pub, chainHash)
+  def computeBIP44Address(pub: PublicKey, chainHash: ByteVector32): String = computeP2PkhAddress(pub, chainHash)
 
   /**
-    *
-    * @param pub       public key
-    * @param chainHash chain hash (i.e. hash of the genesic block of the chain we're on)
-    * @return the p2swh-of-p2pkh address for this key). It is a Base58 address that is compatible with most bitcoin wallets
-    */
+   * @param pub       public key
+   * @param chainHash chain hash (i.e. hash of the genesis block of the chain we're on)
+   * @return the p2swh-of-p2pkh address for this key). It is a Base58 address that is compatible with most bitcoin wallets
+   */
   def computeP2ShOfP2WpkhAddress(pub: PublicKey, chainHash: ByteVector32): String = {
     val script = Script.pay2wpkh(pub)
     val hash = Crypto.hash160(Script.write(script))
@@ -134,15 +132,14 @@ package object bitcoin {
     }
   }
 
-  def computeBIP49Address(pub: PublicKey, chainHash: ByteVector32) = computeP2ShOfP2WpkhAddress(pub, chainHash)
+  def computeBIP49Address(pub: PublicKey, chainHash: ByteVector32): String = computeP2ShOfP2WpkhAddress(pub, chainHash)
 
   /**
-    *
-    * @param pub       public key
-    * @param chainHash chain hash (i.e. hash of the genesic block of the chain we're on)
-    * @return the BIP84 address for this key (i.e. the p2wpkh address for this key). It is a Bech32 address that will be
-    *         understood only by native sewgit wallets
-    */
+   * @param pub       public key
+   * @param chainHash chain hash (i.e. hash of the genesis block of the chain we're on)
+   * @return the BIP84 address for this key (i.e. the p2wpkh address for this key). It is a Bech32 address that will be
+   *         understood only by native sewgit wallets
+   */
   def computeP2WpkhAddress(pub: PublicKey, chainHash: ByteVector32): String = {
     val hash = pub.hash160
     val hrp = chainHash match {
@@ -154,5 +151,60 @@ package object bitcoin {
     Bech32.encodeWitnessAddress(hrp, 0, hash)
   }
 
-  def computeBIP84Address(pub: PublicKey, chainHash: ByteVector32) = computeP2WpkhAddress(pub, chainHash)
+  def computeBIP84Address(pub: PublicKey, chainHash: ByteVector32): String = computeP2WpkhAddress(pub, chainHash)
+
+  /**
+   * @param chainHash hash of the chain (i.e. hash of the genesis block of the chain we're on)
+   * @param script    public key script
+   * @return the address of this public key script on this chain
+   */
+  def computeScriptAddress(chainHash: ByteVector32, script: Seq[ScriptElt]): String = {
+    val base58PubkeyPrefix = chainHash match {
+      case Block.LivenetGenesisBlock.hash => Base58.Prefix.PubkeyAddress
+      case Block.TestnetGenesisBlock.hash | Block.RegtestGenesisBlock.hash => Base58.Prefix.PubkeyAddressTestnet
+      case _ => throw new IllegalArgumentException(s"invalid chain hash $chainHash")
+    }
+    val base58ScriptPrefix = chainHash match {
+      case Block.LivenetGenesisBlock.hash => Base58.Prefix.ScriptAddress
+      case Block.TestnetGenesisBlock.hash | Block.RegtestGenesisBlock.hash => Base58.Prefix.ScriptAddressTestnet
+      case _ => throw new IllegalArgumentException(s"invalid chain hash $chainHash")
+    }
+    val hrp = chainHash match {
+      case Block.LivenetGenesisBlock.hash => "bc"
+      case Block.TestnetGenesisBlock.hash => "tb"
+      case Block.RegtestGenesisBlock.hash => "bcrt"
+      case _ => throw new IllegalArgumentException(s"invalid chain hash $chainHash")
+    }
+    script match {
+      case OP_DUP :: OP_HASH160 :: OP_PUSHDATA(pubKeyHash, _) :: OP_EQUALVERIFY :: OP_CHECKSIG :: Nil => Base58Check.encode(base58PubkeyPrefix, pubKeyHash)
+      case OP_HASH160 :: OP_PUSHDATA(scriptHash, _) :: OP_EQUAL :: Nil => Base58Check.encode(base58ScriptPrefix, scriptHash)
+      case OP_0 :: OP_PUSHDATA(pubKeyHash, _) :: Nil if pubKeyHash.length == 20 => Bech32.encodeWitnessAddress(hrp, 0, pubKeyHash)
+      case OP_0 :: OP_PUSHDATA(scriptHash, _) :: Nil if scriptHash.length == 32 => Bech32.encodeWitnessAddress(hrp, 0, scriptHash)
+      case OP_1 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 1, program)
+      case OP_2 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 2, program)
+      case OP_3 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 3, program)
+      case OP_4 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 4, program)
+      case OP_5 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 5, program)
+      case OP_6 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 6, program)
+      case OP_7 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 7, program)
+      case OP_8 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 8, program)
+      case OP_9 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 9, program)
+      case OP_10 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 10, program)
+      case OP_11 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 11, program)
+      case OP_12 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 12, program)
+      case OP_13 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 13, program)
+      case OP_14 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 14, program)
+      case OP_15 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 15, program)
+      case OP_16 :: OP_PUSHDATA(program, _) :: Nil if 2 <= program.length && program.length <= 40 => Bech32.encodeWitnessAddress(hrp, 16, program)
+      case _ => throw new IllegalArgumentException(s"invalid pubkey script ${Script.write(script)}")
+    }
+  }
+
+  /**
+   * @param chainHash hash of the chain (i.e. hash of the genesis block of the chain we're on)
+   * @param script    public key script
+   * @return the address of this public key script on this chain
+   */
+  def computeScriptAddress(chainHash: ByteVector32, script: ByteVector): String = computeScriptAddress(chainHash, Script.parse(script))
+
 }

--- a/src/test/resources/data/key_io_valid.json
+++ b/src/test/resources/data/key_io_valid.json
@@ -486,7 +486,7 @@
         }
     ],
     [
-        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
         "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
         {
             "isPrivkey": false,
@@ -495,7 +495,7 @@
         }
     ],
     [
-        "bc1sw50qa3jx3s",
+        "bc1sw50qgdz25j",
         "6002751e",
         {
             "isPrivkey": false,
@@ -504,7 +504,7 @@
         }
     ],
     [
-        "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
+        "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs",
         "5210751e76e8199196d454941c45d1b3a323",
         {
             "isPrivkey": false,

--- a/src/test/scala/fr/acinq/bitcoin/BIP84Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/BIP84Spec.scala
@@ -10,7 +10,7 @@ import scodec.bits._
   * see https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
   */
 class BIP84Spec extends FunSuite {
-  test("BIP49 reference tests") {
+  test("BIP84 reference tests") {
     val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "")
     val master = DeterministicWallet.generate(seed)
     assert(DeterministicWallet.encode(master, DeterministicWallet.zprv) == "zprvAWgYBBk7JR8Gjrh4UJQ2uJdG1r3WNRRfURiABBE3RvMXYSrRJL62XuezvGdPvG6GFBZduosCc1YP5wixPox7zhZLfiUm8aunE96BBa4Kei5")

--- a/src/test/scala/fr/acinq/bitcoin/Bech32Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/Bech32Spec.scala
@@ -4,8 +4,8 @@ import org.scalatest.FunSuite
 import scodec.bits._
 
 /**
-  * Created by fabrice on 19/04/17.
-  */
+ * Created by fabrice on 19/04/17.
+ */
 class Bech32Spec extends FunSuite {
   test("valid checksums") {
     val inputs = Seq(
@@ -25,12 +25,16 @@ class Bech32Spec extends FunSuite {
     val inputs = Seq(
       " 1nwldj5",
       "\u007f1axkwrx",
+      "\u00801eym55h",
       "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
       "pzry9x0s0muk",
       "1pzry9x0s0muk",
       "x1b4n0q5v",
       "li1dgmt3",
-      "de1lg7wt\u00ff"
+      "de1lg7wt\u00ff",
+      "A1G7SGD8",
+      "10a06t8",
+      "1qzzfhee"
     )
 
     inputs.map(address => {

--- a/src/test/scala/fr/acinq/bitcoin/Bech32Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/Bech32Spec.scala
@@ -90,10 +90,42 @@ class Bech32Spec extends FunSuite {
 
   test("create addresses") {
     assert(Bech32.encodeWitnessAddress("bc", 0, hex"751e76e8199196d454941c45d1b3a323f1433bd6") == "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4".toLowerCase)
+    assert(computeScriptAddress(Block.LivenetGenesisBlock.hash, hex"0014751e76e8199196d454941c45d1b3a323f1433bd6") == "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4".toLowerCase)
+    assert(Bech32.encodeWitnessAddress("bc", 1, hex"751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6") == "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y")
+    assert(computeScriptAddress(Block.LivenetGenesisBlock.hash, hex"5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6") == "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y")
     assert(Bech32.encodeWitnessAddress("bc", 1, hex"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798") == "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0")
+    assert(computeScriptAddress(Block.LivenetGenesisBlock.hash, hex"512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798") == "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0")
     assert(Bech32.encodeWitnessAddress("tb", 0, hex"1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262") == "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
+    assert(computeScriptAddress(Block.TestnetGenesisBlock.hash, hex"00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262") == "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
     assert(Bech32.encodeWitnessAddress("tb", 0, hex"000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433") == "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy")
+    assert(computeScriptAddress(Block.TestnetGenesisBlock.hash, hex"0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433") == "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy")
     assert(Bech32.encodeWitnessAddress("tb", 1, hex"000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433") == "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c")
+    assert(computeScriptAddress(Block.TestnetGenesisBlock.hash, hex"5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433") == "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c")
+  }
+
+  test("create invalid addresses") {
+    val inputs = Seq(
+      // invalid segwit v0 program length
+      hex"001376e8199196d454941c45d1b3a323f1433bd6a4",
+      hex"0015751e76e8199196d454941c45d1b3a323f1433bd6a4",
+      hex"0019143c8c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+      hex"00211863143c8c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+      // invalid segwit v1-16 program length
+      hex"5101ff",
+      hex"5501aa",
+      hex"51290000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      hex"57290000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      // invalid leading opcode
+      hex"5028751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+      hex"6128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+    )
+    inputs.map(script => {
+      Seq(Block.LivenetGenesisBlock.hash, Block.TestnetGenesisBlock.hash, Block.RegtestGenesisBlock.hash).foreach(chainHash => {
+        intercept[Exception] {
+          computeScriptAddress(chainHash, script)
+        }
+      })
+    })
   }
 
   test("reject invalid addresses") {

--- a/src/test/scala/fr/acinq/bitcoin/Bech32Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/Bech32Spec.scala
@@ -142,7 +142,7 @@ class Bech32Spec extends FunSuite {
     inputs.map {
       case (uri, expected) =>
         val bytes = Bech32.eight2five(uri.getBytes)
-        val encodedLnurl = Bech32.encode("lnurl", bytes)
+        val encodedLnurl = Bech32.encode("lnurl", bytes, Bech32.Bech32Encoding)
         assert(encodedLnurl == expected.toLowerCase)
     }
   }
@@ -154,9 +154,10 @@ class Bech32Spec extends FunSuite {
     )
     inputs.map {
       case (encodedLnurl, expected) =>
-        val (_, decoded) = Bech32.decode(encodedLnurl)
+        val (_, decoded, encoding) = Bech32.decode(encodedLnurl)
+        assert(encoding === Bech32.Bech32Encoding)
         val decodedLnurl = new String(Bech32.five2eight(decoded))
-        assert(decodedLnurl == expected)
+        assert(decodedLnurl === expected)
     }
   }
 

--- a/src/test/scala/fr/acinq/bitcoin/Bech32Spec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/Bech32Spec.scala
@@ -7,15 +7,25 @@ import scodec.bits._
  * Created by fabrice on 19/04/17.
  */
 class Bech32Spec extends FunSuite {
+
   test("valid checksums") {
     val inputs = Seq(
+      // Bech32
       "A12UEL5L",
       "a12uel5l",
       "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
       "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
       "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
       "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
-      "?1ezyfcl"
+      "?1ezyfcl",
+      // Bech32m
+      "A1LQFN3A",
+      "a1lqfn3a",
+      "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6",
+      "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx",
+      "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8",
+      "split1checkupstagehandshakeupstreamerranterredcaperredlc445v",
+      "?1v759aa",
     )
     val outputs = inputs.map(Bech32.decode)
     assert(outputs.length == inputs.length)
@@ -23,6 +33,7 @@ class Bech32Spec extends FunSuite {
 
   test("invalid checksums") {
     val inputs = Seq(
+      // Bech32
       " 1nwldj5",
       "\u007f1axkwrx",
       "\u00801eym55h",
@@ -34,7 +45,22 @@ class Bech32Spec extends FunSuite {
       "de1lg7wt\u00ff",
       "A1G7SGD8",
       "10a06t8",
-      "1qzzfhee"
+      "1qzzfhee",
+      // Bech32m
+      "\u00201xj0phk",
+      "\u007F1g6xzxy",
+      "\u00801vctc34",
+      "an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
+      "qyrz8wqd2c9m",
+      "1qyrz8wqd2c9m",
+      "y1b0jsk6g",
+      "lt1igcx5c0",
+      "in1muywd",
+      "mm1crxm3i",
+      "au1s5cgom",
+      "M1VUXWEZ",
+      "16plkw9",
+      "1p2gdwpf"
     )
 
     inputs.map(address => {
@@ -48,10 +74,12 @@ class Bech32Spec extends FunSuite {
     val inputs = Seq(
       "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4" -> "0014751e76e8199196d454941c45d1b3a323f1433bd6",
       "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7" -> "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-      "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx" -> "8128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
-      "BC1SW50QA3JX3S" -> "9002751e",
-      "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj" -> "8210751e76e8199196d454941c45d1b3a323",
-      "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy" -> "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"
+      "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y" -> "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+      "BC1SW50QGDZ25J" -> "6002751e",
+      "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs" -> "5210751e76e8199196d454941c45d1b3a323",
+      "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy" -> "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+      "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c" -> "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+      "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0" -> "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
     )
     inputs.map {
       case (address, bin) =>
@@ -62,12 +90,15 @@ class Bech32Spec extends FunSuite {
 
   test("create addresses") {
     assert(Bech32.encodeWitnessAddress("bc", 0, hex"751e76e8199196d454941c45d1b3a323f1433bd6") == "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4".toLowerCase)
+    assert(Bech32.encodeWitnessAddress("bc", 1, hex"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798") == "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0")
     assert(Bech32.encodeWitnessAddress("tb", 0, hex"1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262") == "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7")
     assert(Bech32.encodeWitnessAddress("tb", 0, hex"000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433") == "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy")
+    assert(Bech32.encodeWitnessAddress("tb", 1, hex"000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433") == "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c")
   }
 
   test("reject invalid addresses") {
     val addresses = Seq(
+      // Bech32
       "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
       "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
       "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
@@ -79,7 +110,22 @@ class Bech32Spec extends FunSuite {
       "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
       "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
       "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
-      "bc1gmk9yu"
+      "bc1gmk9yu",
+      // Bech32m
+      "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
+      "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
+      "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
+      "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL",
+      "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh",
+      "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
+      "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
+      "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
+      "bc1pw5dgrnzv",
+      "bc1pw5dgrnzv",
+      "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
+      "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
+      "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
+      "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
     )
     addresses.map(address => {
       intercept[Exception] {
@@ -113,4 +159,5 @@ class Bech32Spec extends FunSuite {
         assert(decodedLnurl == expected)
     }
   }
+
 }

--- a/src/test/scala/fr/acinq/bitcoin/reference/KeyEncodingSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/reference/KeyEncodingSpec.scala
@@ -1,7 +1,5 @@
 package fr.acinq.bitcoin.reference
 
-import java.io.InputStreamReader
-
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{Base58, Base58Check, Bech32, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHDATA, Script}
 import org.json4s.DefaultFormats
@@ -10,6 +8,7 @@ import org.json4s.jackson.JsonMethods
 import org.scalatest.FunSuite
 import scodec.bits.ByteVector
 
+import java.io.InputStreamReader
 import scala.util.Try
 
 class KeyEncodingSpec extends FunSuite {
@@ -23,18 +22,16 @@ class KeyEncodingSpec extends FunSuite {
   }
 
   test("invalid keys") {
-    val result = KeyEncodingSpec.isValidBase58("KxuACDviz8Xvpn1xAh9MfopySZNuyajYMZWz16Dv2mHHryznWUp3")
+    assert(!KeyEncodingSpec.isValidBase58("KxuACDviz8Xvpn1xAh9MfopySZNuyajYMZWz16Dv2mHHryznWUp3"))
 
     val stream = classOf[KeyEncodingSpec].getResourceAsStream("/data/key_io_invalid.json")
     val json = JsonMethods.parse(new InputStreamReader(stream))
 
     json.extract[List[List[JValue]]].foreach {
-      _ match {
-        case JString(value) :: Nil =>
-          assert(!KeyEncodingSpec.isValidBase58(value))
-          assert(!KeyEncodingSpec.isValidBech32(value))
-        case unexpected => throw new IllegalArgumentException(s"don't know how to parse $unexpected")
-      }
+      case JString(value) :: Nil =>
+        assert(!KeyEncodingSpec.isValidBase58(value))
+        assert(!KeyEncodingSpec.isValidBech32(value))
+      case unexpected => throw new IllegalArgumentException(s"don't know how to parse $unexpected")
     }
   }
 }
@@ -47,14 +44,14 @@ object KeyEncodingSpec {
       case Base58.Prefix.PubkeyAddress | Base58.Prefix.PubkeyAddressTestnet => bin.length == 20
       case _ => false
     }
-  } getOrElse (false)
+  } getOrElse false
 
   def isValidBech32(input: String): Boolean = Try {
     Bech32.decodeWitnessAddress(input) match {
       case (hrp, 0, bin) if (hrp == "bc" || hrp == "tb" || hrp == "bcrt") && (bin.length == 20 || bin.length == 32) => true
       case _ => false
     }
-  } getOrElse (false)
+  } getOrElse false
 
   def check(data: List[JValue]): Unit = {
     data match {


### PR DESCRIPTION
This support will be necessary for future P2TR addresses.
We add forward-compatible support for segwit v1-16 as suggested in [BIP 350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).