### PR TITLE
Tell maven to compile against JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>2.13.3</scala.version>
         <scala.version.short>2.13</scala.version.short>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <licenses>


### PR DESCRIPTION
<maven.compiler.source/> and <maven.compiler.target/>.

Some IDE will show warnings without them.
And they have been added in pom.xml of Ecliair.