### PR TITLE
Improve PSBT types

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,14 +446,14 @@ Bitcoin-lib is *not* compatible with Bitcoin Core versions before 0.20.1, becaus
     )
 
     // Alice signs both inputs:
-    val Success(signedByAlice) = bothInputsFilled
+    val Success(SignPsbtResult(signedByAlice, _)) = bothInputsFilled
       .sign(aliceKeyNonWitness, 0)
-      .flatMap(_.sign(aliceKeyWitness, 1))
+      .flatMap(_.psbt.sign(aliceKeyWitness, 1))
 
     // Bob signs both inputs:
-    val Success(signedByBob) = signedByAlice
+    val Success(SignPsbtResult(signedByBob, _)) = signedByAlice
       .sign(bobKeyNonWitness, 0)
-      .flatMap(_.sign(bobKeyWitness, 1))
+      .flatMap(_.psbt.sign(bobKeyWitness, 1))
 
     // Finalize inputs and extract transaction:
     val Success(tx) = {

--- a/src/main/scala/fr/acinq/bitcoin/Psbt.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Psbt.scala
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success, Try}
  * @param inputs  signing data for each input of the transaction to be signed (order matches the unsigned tx).
  * @param outputs signing data for each output of the transaction to be signed (order matches the unsigned tx).
  */
-case class Psbt(global: Psbt.Global, inputs: Seq[Psbt.PartiallySignedInput], outputs: Seq[Psbt.PartiallySignedOutput]) {
+case class Psbt(global: Psbt.Global, inputs: Seq[Psbt.Input], outputs: Seq[Psbt.Output]) {
 
   import Psbt._
 
@@ -24,41 +24,183 @@ case class Psbt(global: Psbt.Global, inputs: Seq[Psbt.PartiallySignedInput], out
   require(global.tx.txOut.length == outputs.length, "there must be one partially signed output per output of the unsigned tx")
 
   /**
-   * Implements the PSBT updater role; adds information about a given UTXO.
+   * Implements the PSBT updater role; adds information about a given segwit utxo.
    * Note that we always fill the nonWitnessUtxo (see https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#cite_note-7).
    *
-   * @param inputTx         transaction containing the UTXO.
-   * @param outputIndex     index of the UTXO in the inputTx.
-   * @param redeemScript    redeem script if known and applicable.
-   * @param witnessScript   witness script if known and applicable.
+   * @param inputTx         transaction containing the utxo.
+   * @param outputIndex     index of the utxo in the inputTx.
+   * @param redeemScript    redeem script if known and applicable (when using p2sh-embedded segwit).
+   * @param witnessScript   witness script if known and applicable (when using p2wsh).
    * @param sighashType     sighash type if one should be specified.
-   * @param derivationPaths derivation paths for keys used by this UTXO.
+   * @param derivationPaths derivation paths for keys used by this utxo.
    * @return psbt with the matching input updated.
    */
-  def update(inputTx: Transaction,
-             outputIndex: Int,
-             redeemScript: Option[Seq[ScriptElt]] = None,
-             witnessScript: Option[Seq[ScriptElt]] = None,
-             sighashType: Option[Int] = None,
-             derivationPaths: Map[PublicKey, KeyPathWithMaster] = Map.empty): Try[Psbt] = Try {
+  def updateWitnessInput(inputTx: Transaction,
+                         outputIndex: Int,
+                         redeemScript: Option[Seq[ScriptElt]] = None,
+                         witnessScript: Option[Seq[ScriptElt]] = None,
+                         sighashType: Option[Int] = None,
+                         derivationPaths: Map[PublicKey, KeyPathWithMaster] = Map.empty): Try[Psbt] = Try {
     require(outputIndex < inputTx.txOut.size, "output index must exist in the input tx")
     val outpoint = OutPoint(inputTx, outputIndex)
     val inputIndex = global.tx.txIn.indexWhere(_.outPoint == outpoint)
     require(inputIndex >= 0, "psbt transaction does not spend the provided outpoint")
-    val input = inputs(inputIndex)
-    val withUtxo = if (witnessScript.nonEmpty) {
-      input.copy(
-        witnessUtxo = Some(inputTx.txOut(outputIndex)), redeemScript = redeemScript.orElse(input.redeemScript), witnessScript = witnessScript,
-        nonWitnessUtxo = Some(inputTx)
+    val updatedInput = inputs(inputIndex) match {
+      case input: PartiallySignedInputWithoutUtxo => PartiallySignedWitnessInput(
+        inputTx.txOut(outputIndex),
+        Some(inputTx),
+        sighashType.orElse(input.sighashType),
+        Map.empty,
+        derivationPaths ++ input.derivationPaths,
+        redeemScript,
+        witnessScript,
+        input.ripemd160,
+        input.sha256,
+        input.hash160,
+        input.hash256,
+        input.unknown
       )
-    } else {
-      input.copy(nonWitnessUtxo = Some(inputTx), redeemScript = redeemScript.orElse(input.redeemScript))
+      case input: PartiallySignedWitnessInput => input.copy(
+        txOut = inputTx.txOut(outputIndex),
+        nonWitnessUtxo = Some(inputTx),
+        redeemScript = redeemScript.orElse(input.redeemScript),
+        witnessScript = witnessScript.orElse(input.witnessScript),
+        sighashType = sighashType.orElse(input.sighashType),
+        derivationPaths = input.derivationPaths ++ derivationPaths
+      )
+      case _: PartiallySignedNonWitnessInput => return Failure(new IllegalArgumentException("cannot update segwit input: it has already been updated with non-segwit data"))
+      case _: FinalizedInput => return Failure(new IllegalArgumentException("cannot update segwit input: it has already been finalized"))
     }
-    val withSigHashAndDerivation = withUtxo.copy(
-      sighashType = sighashType.orElse(input.sighashType),
-      derivationPaths = input.derivationPaths ++ derivationPaths
-    )
-    this.copy(inputs = inputs.updated(inputIndex, withSigHashAndDerivation))
+    this.copy(inputs = inputs.updated(inputIndex, updatedInput))
+  }
+
+  /**
+   * Implements the PSBT updater role; adds information about a given non-segwit utxo.
+   *
+   * @param inputTx         transaction containing the utxo.
+   * @param outputIndex     index of the utxo in the inputTx.
+   * @param redeemScript    redeem script if known and applicable (when using p2sh).
+   * @param sighashType     sighash type if one should be specified.
+   * @param derivationPaths derivation paths for keys used by this utxo.
+   * @return psbt with the matching input updated.
+   */
+  def updateNonWitnessInput(inputTx: Transaction,
+                            outputIndex: Int,
+                            redeemScript: Option[Seq[ScriptElt]] = None,
+                            sighashType: Option[Int] = None,
+                            derivationPaths: Map[PublicKey, KeyPathWithMaster] = Map.empty): Try[Psbt] = Try {
+    require(outputIndex < inputTx.txOut.size, "output index must exist in the input tx")
+    val outpoint = OutPoint(inputTx, outputIndex)
+    val inputIndex = global.tx.txIn.indexWhere(_.outPoint == outpoint)
+    require(inputIndex >= 0, "psbt transaction does not spend the provided outpoint")
+    val updatedInput = inputs(inputIndex) match {
+      case input: PartiallySignedInputWithoutUtxo => PartiallySignedNonWitnessInput(
+        inputTx,
+        outputIndex,
+        sighashType.orElse(input.sighashType),
+        Map.empty,
+        derivationPaths ++ input.derivationPaths,
+        redeemScript,
+        input.ripemd160,
+        input.sha256,
+        input.hash160,
+        input.hash256,
+        input.unknown
+      )
+      case input: PartiallySignedNonWitnessInput => input.copy(
+        inputTx = inputTx,
+        outputIndex = outputIndex,
+        redeemScript = redeemScript.orElse(input.redeemScript),
+        sighashType = sighashType.orElse(input.sighashType),
+        derivationPaths = input.derivationPaths ++ derivationPaths
+      )
+      case _: PartiallySignedWitnessInput => return Failure(new IllegalArgumentException("cannot update non-segwit input: it has already been updated with segwit data"))
+      case _: FinalizedInput => return Failure(new IllegalArgumentException("cannot update non-segwit input: it has already been finalized"))
+    }
+    this.copy(inputs = inputs.updated(inputIndex, updatedInput))
+  }
+
+  def updatePreimageChallenges(outPoint: OutPoint, ripemd160: Set[ByteVector], sha256: Set[ByteVector], hash160: Set[ByteVector], hash256: Set[ByteVector]): Try[Psbt] = {
+    val inputIndex = global.tx.txIn.indexWhere(_.outPoint == outPoint)
+    require(inputIndex >= 0, "psbt transaction does not spend the provided outpoint")
+    updatePreimageChallenges(inputIndex, ripemd160, sha256, hash160, hash256)
+  }
+
+  def updatePreimageChallenges(inputIndex: Int, ripemd160: Set[ByteVector], sha256: Set[ByteVector], hash160: Set[ByteVector], hash256: Set[ByteVector]): Try[Psbt] = Try {
+    require(inputIndex < inputs.length, "input must exist in the global tx")
+    val updatedInput = inputs(inputIndex) match {
+      case input: PartiallySignedInputWithoutUtxo => input.copy(ripemd160 = ripemd160 ++ input.ripemd160, sha256 = sha256 ++ input.sha256, hash160 = hash160 ++ input.hash160, hash256 = hash256 ++ input.hash256)
+      case input: PartiallySignedWitnessInput => input.copy(ripemd160 = ripemd160 ++ input.ripemd160, sha256 = sha256 ++ input.sha256, hash160 = hash160 ++ input.hash160, hash256 = hash256 ++ input.hash256)
+      case input: PartiallySignedNonWitnessInput => input.copy(ripemd160 = ripemd160 ++ input.ripemd160, sha256 = sha256 ++ input.sha256, hash160 = hash160 ++ input.hash160, hash256 = hash256 ++ input.hash256)
+      case input: FinalizedWitnessInput => input.copy(ripemd160 = ripemd160 ++ input.ripemd160, sha256 = sha256 ++ input.sha256, hash160 = hash160 ++ input.hash160, hash256 = hash256 ++ input.hash256)
+      case input: FinalizedNonWitnessInput => input.copy(ripemd160 = ripemd160 ++ input.ripemd160, sha256 = sha256 ++ input.sha256, hash160 = hash160 ++ input.hash160, hash256 = hash256 ++ input.hash256)
+      case input: FinalizedInputWithoutUtxo => input.copy(ripemd160 = ripemd160 ++ input.ripemd160, sha256 = sha256 ++ input.sha256, hash160 = hash160 ++ input.hash160, hash256 = hash256 ++ input.hash256)
+    }
+    this.copy(inputs = inputs.updated(inputIndex, updatedInput))
+  }
+
+  /**
+   * Add details for a segwit output.
+   *
+   * @param outputIndex     index of the output in the psbt.
+   * @param witnessScript   witness script if known and applicable (when using p2wsh).
+   * @param redeemScript    redeem script if known and applicable (when using p2sh-embedded segwit).
+   * @param derivationPaths derivation paths for keys used by this output.
+   * @return psbt with the matching output updated.
+   */
+  def updateWitnessOutput(outputIndex: Int,
+                          witnessScript: Option[Seq[ScriptElt]] = None,
+                          redeemScript: Option[Seq[ScriptElt]] = None,
+                          derivationPaths: Map[PublicKey, KeyPathWithMaster] = Map.empty): Try[Psbt] = Try {
+    require(outputIndex < global.tx.txOut.size, "output index must exist in the global tx")
+    val updatedOutput = outputs(outputIndex) match {
+      case _: NonWitnessOutput => return Failure(new IllegalArgumentException("cannot update segwit output: it has already been updated with non-segwit data"))
+      case output: WitnessOutput => output.copy(
+        witnessScript = witnessScript.orElse(output.witnessScript),
+        redeemScript = redeemScript.orElse(output.redeemScript),
+        derivationPaths = derivationPaths ++ output.derivationPaths
+      )
+      case output: UnspecifiedOutput => WitnessOutput(witnessScript, redeemScript, derivationPaths ++ output.derivationPaths, output.unknown)
+    }
+    this.copy(outputs = outputs.updated(outputIndex, updatedOutput))
+  }
+
+  /**
+   * Add details for a non-segwit output.
+   *
+   * @param outputIndex     index of the output in the psbt.
+   * @param redeemScript    redeem script if known and applicable (when using p2sh).
+   * @param derivationPaths derivation paths for keys used by this output.
+   * @return psbt with the matching output updated.
+   */
+  def updateNonWitnessOutput(outputIndex: Int,
+                             redeemScript: Option[Seq[ScriptElt]] = None,
+                             derivationPaths: Map[PublicKey, KeyPathWithMaster] = Map.empty): Try[Psbt] = Try {
+    require(outputIndex < global.tx.txOut.size, "output index must exist in the global tx")
+    val updatedOutput = outputs(outputIndex) match {
+      case output: NonWitnessOutput => output.copy(
+        redeemScript = redeemScript.orElse(output.redeemScript),
+        derivationPaths = derivationPaths ++ output.derivationPaths
+      )
+      case _: WitnessOutput => return Failure(new IllegalArgumentException("cannot update non-segwit output: it has already been updated with segwit data"))
+      case output: UnspecifiedOutput => NonWitnessOutput(redeemScript, derivationPaths ++ output.derivationPaths, output.unknown)
+    }
+    this.copy(outputs = outputs.updated(outputIndex, updatedOutput))
+  }
+
+  /**
+   * Implements the PSBT signer role: sign a given input.
+   * The caller needs to carefully verify that it wants to spend that input, and that the unsigned transaction matches
+   * what it expects.
+   *
+   * @param priv     private key used to sign the input.
+   * @param outPoint input that should be signed.
+   * @return the psbt with a partial signature added (other inputs will not be modified).
+   */
+  def sign(priv: PrivateKey, outPoint: OutPoint): Try[Psbt] = {
+    val inputIndex = global.tx.txIn.indexWhere(_.outPoint == outPoint)
+    require(inputIndex >= 0, "psbt transaction does not spend the provided outpoint")
+    sign(priv, inputIndex)
   }
 
   /**
@@ -80,59 +222,76 @@ case class Psbt(global: Psbt.Global, inputs: Seq[Psbt.PartiallySignedInput], out
   }
 
   /**
-   * Implements the PSBT finalizer role: finalizes a given non-witness input.
-   * This will clear all fields from the input except the utxo, scriptSig and unknown entries.
+   * Implements the PSBT finalizer role: finalizes a given segwit input.
+   * This will clear all fields from the input except the utxo, scriptSig, scriptWitness and unknown entries.
    *
-   * @param inputIndex index of the input that should be finalized.
-   * @param scriptSig  signature script.
+   * @param outPoint      input that should be finalized.
+   * @param scriptWitness witness script.
    * @return a psbt with the given input finalized.
    */
-  def finalize(inputIndex: Int, scriptSig: Seq[ScriptElt]): Try[Psbt] = {
-    if (inputIndex >= inputs.length) {
-      Failure(new IllegalArgumentException("input index must exist in the input tx"))
-    } else {
-      inputs(inputIndex) match {
-        case input if input.nonWitnessUtxo.isEmpty => Failure(new IllegalArgumentException("cannot finalize: non-witness utxo is missing"))
-        case input =>
-          val finalizedInput = input.copy(
-            sighashType = None,
-            partialSigs = Map.empty,
-            derivationPaths = Map.empty,
-            redeemScript = None,
-            witnessScript = None,
-            scriptSig = Some(scriptSig)
-          )
-          Success(this.copy(inputs = this.inputs.updated(inputIndex, finalizedInput)))
-      }
-    }
+  def finalizeWitnessInput(outPoint: OutPoint, scriptWitness: ScriptWitness): Try[Psbt] = {
+    val inputIndex = global.tx.txIn.indexWhere(_.outPoint == outPoint)
+    require(inputIndex >= 0, "psbt transaction does not spend the provided outpoint")
+    finalizeWitnessInput(inputIndex, scriptWitness)
   }
 
   /**
-   * Implements the PSBT finalizer role: finalizes a given witness input.
+   * Implements the PSBT finalizer role: finalizes a given segwit input.
    * This will clear all fields from the input except the utxo, scriptSig, scriptWitness and unknown entries.
    *
    * @param inputIndex    index of the input that should be finalized.
    * @param scriptWitness witness script.
    * @return a psbt with the given input finalized.
    */
-  def finalize(inputIndex: Int, scriptWitness: ScriptWitness): Try[Psbt] = {
+  def finalizeWitnessInput(inputIndex: Int, scriptWitness: ScriptWitness): Try[Psbt] = {
     if (inputIndex >= inputs.length) {
       Failure(new IllegalArgumentException("input index must exist in the input tx"))
     } else {
       inputs(inputIndex) match {
-        case input if input.witnessUtxo.isEmpty => Failure(new IllegalArgumentException("cannot finalize: witness utxo is missing"))
-        case input =>
-          val scriptSig = input.redeemScript.map(script => OP_PUSHDATA(Script.write(script)) :: Nil)
-          val finalizedInput = input.copy(
-            sighashType = None,
-            partialSigs = Map.empty,
-            derivationPaths = Map.empty,
-            redeemScript = None,
-            witnessScript = None,
-            scriptSig = scriptSig,
-            scriptWitness = Some(scriptWitness)
-          )
+        case _: PartiallySignedInputWithoutUtxo => Failure(new IllegalArgumentException("cannot finalize: input is missing utxo details"))
+        case _: PartiallySignedNonWitnessInput => Failure(new IllegalArgumentException("cannot finalize: input is a non-segwit input"))
+        case input: PartiallySignedWitnessInput =>
+          val scriptSig = input.redeemScript.map(script => OP_PUSHDATA(Script.write(script)) :: Nil) // p2sh-embedded segwit
+          val finalizedInput = FinalizedWitnessInput(input.txOut, input.nonWitnessUtxo, scriptWitness, scriptSig, input.ripemd160, input.sha256, input.hash160, input.hash256, input.unknown)
           Success(this.copy(inputs = this.inputs.updated(inputIndex, finalizedInput)))
+        case _: FinalizedInput => Failure(new IllegalArgumentException("cannot finalize: input has already been finalized"))
+      }
+    }
+  }
+
+  /**
+   * Implements the PSBT finalizer role: finalizes a given non-segwit input.
+   * This will clear all fields from the input except the utxo, scriptSig and unknown entries.
+   *
+   * @param outPoint  input that should be finalized.
+   * @param scriptSig signature script.
+   * @return a psbt with the given input finalized.
+   */
+  def finalizeNonWitnessInput(outPoint: OutPoint, scriptSig: Seq[ScriptElt]): Try[Psbt] = {
+    val inputIndex = global.tx.txIn.indexWhere(_.outPoint == outPoint)
+    require(inputIndex >= 0, "psbt transaction does not spend the provided outpoint")
+    finalizeNonWitnessInput(inputIndex, scriptSig)
+  }
+
+  /**
+   * Implements the PSBT finalizer role: finalizes a given non-segwit input.
+   * This will clear all fields from the input except the utxo, scriptSig and unknown entries.
+   *
+   * @param inputIndex index of the input that should be finalized.
+   * @param scriptSig  signature script.
+   * @return a psbt with the given input finalized.
+   */
+  def finalizeNonWitnessInput(inputIndex: Int, scriptSig: Seq[ScriptElt]): Try[Psbt] = {
+    if (inputIndex >= inputs.length) {
+      Failure(new IllegalArgumentException("input index must exist in the input tx"))
+    } else {
+      inputs(inputIndex) match {
+        case _: PartiallySignedInputWithoutUtxo => Failure(new IllegalArgumentException("cannot finalize: input is missing utxo details"))
+        case _: PartiallySignedWitnessInput => Failure(new IllegalArgumentException("cannot finalize: input is a segwit input"))
+        case input: PartiallySignedNonWitnessInput =>
+          val finalizedInput = FinalizedNonWitnessInput(input.inputTx, input.outputIndex, scriptSig, input.ripemd160, input.sha256, input.hash160, input.hash256, input.unknown)
+          Success(this.copy(inputs = this.inputs.updated(inputIndex, finalizedInput)))
+        case _: FinalizedInput => Failure(new IllegalArgumentException("cannot finalize: input has already been finalized"))
       }
     }
   }
@@ -144,17 +303,17 @@ case class Psbt(global: Psbt.Global, inputs: Seq[Psbt.PartiallySignedInput], out
    */
   def extract(): Try[Transaction] = {
     val (finalTxsIn, utxos) = global.tx.txIn.zip(inputs).map {
-      case (_, input) if !isFinal(input) => return Failure(new IllegalArgumentException("cannot extract transaction: some inputs are not finalized"))
       case (txIn, input) =>
         val finalTxIn = txIn.copy(
           witness = input.scriptWitness.getOrElse(ScriptWitness.empty),
-          signatureScript = input.scriptSig.map(Script.write).getOrElse(ByteVector.empty))
+          signatureScript = input.scriptSig.map(Script.write).getOrElse(ByteVector.empty)
+        )
         val utxo = input match {
-          case PartiallySignedInput(Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _, _) if utxo.txid != txIn.outPoint.txid => return Failure(new IllegalArgumentException("cannot extract transaction: non-witness utxo does not match unsigned tx input"))
-          case PartiallySignedInput(Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _, _) if utxo.txOut.length <= txIn.outPoint.index => return Failure(new IllegalArgumentException("cannot extract transaction: non-witness utxo index out of bounds"))
-          case PartiallySignedInput(Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _, _) => utxo.txOut(txIn.outPoint.index.toInt)
-          case PartiallySignedInput(_, Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _) => utxo
-          case _ => return Failure(new IllegalArgumentException("cannot extract transaction: some utxos are missing"))
+          case input: FinalizedNonWitnessInput if input.inputTx.txid != txIn.outPoint.txid => return Failure(new IllegalArgumentException("cannot extract transaction: non-witness utxo does not match unsigned tx input"))
+          case input: FinalizedNonWitnessInput if input.inputTx.txOut.length <= txIn.outPoint.index => return Failure(new IllegalArgumentException("cannot extract transaction: non-witness utxo index out of bounds"))
+          case input: FinalizedNonWitnessInput => input.inputTx.txOut(txIn.outPoint.index.toInt)
+          case input: FinalizedWitnessInput => input.txOut
+          case _ => return Failure(new IllegalArgumentException("cannot extract transaction: some inputs are not finalized or are missing utxo data"))
         }
         (finalTxIn, txIn.outPoint -> utxo)
     }.unzip
@@ -173,16 +332,22 @@ case class Psbt(global: Psbt.Global, inputs: Seq[Psbt.PartiallySignedInput], out
       case Nil => 0 sat
       case txOut => txOut.map(_.amount).sum
     }
-    val amountIn = inputs.zip(global.tx.txIn).foldLeft(Success(0 sat): Try[Satoshi]) {
+    val amountIn = inputs.foldLeft(Success(0 sat): Try[Satoshi]) {
       case (Failure(ex), _) => Failure(ex)
-      case (Success(amount), (input, txIn)) =>
-        val inputAmount_opt = input.witnessUtxo.map(_.amount).orElse(input.nonWitnessUtxo.map(tx => tx.txOut(txIn.outPoint.index.toInt).amount))
-        inputAmount_opt match {
-          case Some(inputAmount) => Success(amount + inputAmount)
-          case None => Failure(new IllegalArgumentException(s"input ${txIn.outPoint} has not been updated: amount unknown"))
-        }
+      case (Success(amount), input: WitnessInput) => Success(amount + input.amount)
+      case (Success(amount), input: NonWitnessInput) => Success(amount + input.amount)
+      case _ => Failure(new IllegalArgumentException(s"some inputs are missing utxo details: amount unknown"))
     }
     amountIn.map(_ - amountOut)
+  }
+
+  def getInput(outPoint: OutPoint): Option[Input] = {
+    val inputIndex = global.tx.txIn.indexWhere(_.outPoint == outPoint)
+    if (inputIndex >= 0) Some(inputs(inputIndex)) else None
+  }
+
+  def getInput(inputIndex: Int): Option[Input] = {
+    if (0 <= inputIndex && inputIndex < inputs.size) Some(inputs(inputIndex)) else None
   }
 
 }
@@ -226,54 +391,186 @@ object Psbt {
    */
   case class Global(version: Long, tx: Transaction, extendedPublicKeys: Seq[ExtendedPublicKeyWithMaster], unknown: Seq[DataEntry]) extends DataMap
 
-  /**
-   * A partially signed input. A valid PSBT must contain one such input per input of the [[Global.tx]].
-   *
-   * @param nonWitnessUtxo  non-witness utxo, used when spending non-segwit outputs.
-   * @param witnessUtxo     witness utxo, used when spending segwit outputs.
-   * @param sighashType     sighash type to be used when producing signature for this output.
-   * @param partialSigs     signatures as would be pushed to the stack from a scriptSig or witness.
-   * @param derivationPaths derivation paths used for the signatures.
-   * @param redeemScript    redeemScript for this input if it has one.
-   * @param witnessScript   witnessScript for this input if it has one.
-   * @param scriptSig       fully constructed scriptSig with signatures and any other scripts necessary for the input to pass validation.
-   * @param scriptWitness   fully constructed scriptWitness with signatures and any other scripts necessary for the input to pass validation.
-   * @param unknown         (optional) unknown global entries.
-   */
-  case class PartiallySignedInput(nonWitnessUtxo: Option[Transaction],
-                                  witnessUtxo: Option[TxOut],
-                                  sighashType: Option[Int],
-                                  partialSigs: Map[PublicKey, ByteVector],
-                                  derivationPaths: Map[PublicKey, KeyPathWithMaster],
-                                  redeemScript: Option[Seq[ScriptElt]],
-                                  witnessScript: Option[Seq[ScriptElt]],
-                                  scriptSig: Option[Seq[ScriptElt]],
-                                  scriptWitness: Option[ScriptWitness],
-                                  ripemd160: Set[ByteVector],
-                                  sha256: Set[ByteVector],
-                                  hash160: Set[ByteVector],
-                                  hash256: Set[ByteVector],
-                                  unknown: Seq[DataEntry]) extends DataMap
+  /** A PSBT input. A valid PSBT must contain one such input per input of the [[Global.tx]]. */
+  sealed trait Input extends DataMap {
+    // @formatter:off
+    /** Non-witness utxo, used when spending non-segwit outputs (may also be included when spending segwit outputs). */
+    def nonWitnessUtxo: Option[Transaction]
+    /** Witness utxo, used when spending segwit outputs. */
+    def witnessUtxo: Option[TxOut]
+    /** Sighash type to be used when producing signatures for this output. */
+    def sighashType: Option[Int]
+    /** Signatures as would be pushed to the stack from a scriptSig or witness. */
+    def partialSigs: Map[PublicKey, ByteVector]
+    /** Derivation paths used for the signatures. */
+    def derivationPaths: Map[PublicKey, KeyPathWithMaster]
+    /** Redeem script for this input (when using p2sh). */
+    def redeemScript: Option[Seq[ScriptElt]]
+    /** Witness script for this input (when using p2wsh). */
+    def witnessScript: Option[Seq[ScriptElt]]
+    /** Fully constructed scriptSig with signatures and any other scripts necessary for the input to pass validation. */
+    def scriptSig: Option[Seq[ScriptElt]]
+    /** Fully constructed scriptWitness with signatures and any other scripts necessary for the input to pass validation. */
+    def scriptWitness: Option[ScriptWitness]
+    /** RipeMD160 preimages (e.g. for miniscript hash challenges). */
+    def ripemd160: Set[ByteVector]
+    /** Sha256 preimages (e.g. for miniscript hash challenges). */
+    def sha256: Set[ByteVector]
+    /** Hash160 preimages (e.g. for miniscript hash challenges). */
+    def hash160: Set[ByteVector]
+    /** Hash256 preimages (e.g. for miniscript hash challenges). */
+    def hash256: Set[ByteVector]
+    /** (optional) Unknown global entries. */
+    def unknown: Seq[DataEntry]
+    // @formatter:on
+  }
 
-  object PartiallySignedInput {
-    val empty: PartiallySignedInput = PartiallySignedInput(None, None, None, Map.empty, Map.empty, None, None, None, None, Set.empty, Set.empty, Set.empty, Set.empty, Nil)
+  /** An input spending a segwit output. */
+  sealed trait WitnessInput extends Input {
+    // @formatter:off
+    def txOut: TxOut
+    def amount: Satoshi = txOut.amount
+    override val witnessUtxo: Option[TxOut] = Some(txOut)
+    // @formatter:on
+  }
+
+  /** An input spending a non-segwit output. */
+  sealed trait NonWitnessInput extends Input {
+    // @formatter:off
+    def inputTx: Transaction
+    def outputIndex: Int
+    def amount: Satoshi = inputTx.txOut(outputIndex).amount
+    override val nonWitnessUtxo: Option[Transaction] = Some(inputTx)
+    // The following fields should only be present for inputs which spend segwit outputs (including P2SH embedded ones).
+    override val witnessUtxo: Option[TxOut] = None
+    override val witnessScript: Option[Seq[ScriptElt]] = None
+    // @formatter:on
+  }
+
+  /** A partially signed input. More signatures may need to be added before it can be finalized. */
+  sealed trait PartiallySignedInput extends Input {
+    override val scriptSig: Option[Seq[ScriptElt]] = None
+    override val scriptWitness: Option[ScriptWitness] = None
+  }
+
+  case class PartiallySignedInputWithoutUtxo(sighashType: Option[Int],
+                                             derivationPaths: Map[PublicKey, KeyPathWithMaster],
+                                             ripemd160: Set[ByteVector],
+                                             sha256: Set[ByteVector],
+                                             hash160: Set[ByteVector],
+                                             hash256: Set[ByteVector],
+                                             unknown: Seq[DataEntry]) extends PartiallySignedInput {
+    override val nonWitnessUtxo: Option[Transaction] = None
+    override val witnessUtxo: Option[TxOut] = None
+    override val redeemScript: Option[Seq[ScriptElt]] = None
+    override val witnessScript: Option[Seq[ScriptElt]] = None
+    override val partialSigs: Map[PublicKey, ByteVector] = Map.empty
+  }
+
+  case class PartiallySignedWitnessInput(txOut: TxOut,
+                                         nonWitnessUtxo: Option[Transaction],
+                                         sighashType: Option[Int],
+                                         partialSigs: Map[PublicKey, ByteVector],
+                                         derivationPaths: Map[PublicKey, KeyPathWithMaster],
+                                         redeemScript: Option[Seq[ScriptElt]],
+                                         witnessScript: Option[Seq[ScriptElt]],
+                                         ripemd160: Set[ByteVector],
+                                         sha256: Set[ByteVector],
+                                         hash160: Set[ByteVector],
+                                         hash256: Set[ByteVector],
+                                         unknown: Seq[DataEntry]) extends PartiallySignedInput with WitnessInput
+
+  case class PartiallySignedNonWitnessInput(inputTx: Transaction,
+                                            outputIndex: Int,
+                                            sighashType: Option[Int],
+                                            partialSigs: Map[PublicKey, ByteVector],
+                                            derivationPaths: Map[PublicKey, KeyPathWithMaster],
+                                            redeemScript: Option[Seq[ScriptElt]],
+                                            ripemd160: Set[ByteVector],
+                                            sha256: Set[ByteVector],
+                                            hash160: Set[ByteVector],
+                                            hash256: Set[ByteVector],
+                                            unknown: Seq[DataEntry]) extends PartiallySignedInput with NonWitnessInput
+
+  /** A fully signed input. */
+  sealed trait FinalizedInput extends Input {
+    override val sighashType: Option[Int] = None
+    override val partialSigs: Map[PublicKey, ByteVector] = Map.empty
+    override val derivationPaths: Map[PublicKey, KeyPathWithMaster] = Map.empty
+    override val redeemScript: Option[Seq[ScriptElt]] = None
+    override val witnessScript: Option[Seq[ScriptElt]] = None
+  }
+
+  case class FinalizedWitnessInput(txOut: TxOut,
+                                   nonWitnessUtxo: Option[Transaction],
+                                   finalScriptWitness: ScriptWitness,
+                                   scriptSig: Option[Seq[ScriptElt]],
+                                   ripemd160: Set[ByteVector],
+                                   sha256: Set[ByteVector],
+                                   hash160: Set[ByteVector],
+                                   hash256: Set[ByteVector],
+                                   unknown: Seq[DataEntry]) extends FinalizedInput with WitnessInput {
+    override val scriptWitness: Option[ScriptWitness] = Some(finalScriptWitness)
+  }
+
+  case class FinalizedNonWitnessInput(inputTx: Transaction,
+                                      outputIndex: Int,
+                                      finalScriptSig: Seq[ScriptElt],
+                                      ripemd160: Set[ByteVector],
+                                      sha256: Set[ByteVector],
+                                      hash160: Set[ByteVector],
+                                      hash256: Set[ByteVector],
+                                      unknown: Seq[DataEntry]) extends FinalizedInput with NonWitnessInput {
+    override val scriptSig: Option[Seq[ScriptElt]] = Some(finalScriptSig)
+    override val scriptWitness: Option[ScriptWitness] = None
   }
 
   /**
-   * A partially signed output. A valid PSBT must contain one such output per output of the [[Global.tx]].
-   *
-   * @param redeemScript    redeemScript for this output if it has one.
-   * @param witnessScript   witnessScript for this output if it has one.
-   * @param derivationPaths derivation paths used to produce the public keys associated to this output.
-   * @param unknown         (optional) unknown global entries.
+   * Input finalizers should keep the utxo to allow transaction extractors to verify the final network serialized
+   * transaction, but it's not mandatory so we may not have it available when parsing psbt inputs.
    */
-  case class PartiallySignedOutput(redeemScript: Option[Seq[ScriptElt]],
-                                   witnessScript: Option[Seq[ScriptElt]],
-                                   derivationPaths: Map[PublicKey, KeyPathWithMaster],
-                                   unknown: Seq[DataEntry]) extends DataMap
+  case class FinalizedInputWithoutUtxo(scriptWitness: Option[ScriptWitness],
+                                       scriptSig: Option[Seq[ScriptElt]],
+                                       ripemd160: Set[ByteVector],
+                                       sha256: Set[ByteVector],
+                                       hash160: Set[ByteVector],
+                                       hash256: Set[ByteVector],
+                                       unknown: Seq[DataEntry]) extends FinalizedInput {
+    override val nonWitnessUtxo: Option[Transaction] = None
+    override val witnessUtxo: Option[TxOut] = None
+  }
 
-  object PartiallySignedOutput {
-    val empty: PartiallySignedOutput = PartiallySignedOutput(None, None, Map.empty, Nil)
+  /** A PSBT output. A valid PSBT must contain one such output per output of the [[Global.tx]]. */
+  sealed trait Output extends DataMap {
+    // @formatter:off
+    /** Redeem script for this output (when using p2sh). */
+    def redeemScript: Option[Seq[ScriptElt]]
+    /** Witness script for this output (when using p2wsh). */
+    def witnessScript: Option[Seq[ScriptElt]]
+    /** Derivation paths used to produce the public keys associated to this output. */
+    def derivationPaths: Map[PublicKey, KeyPathWithMaster]
+    /** (optional) Unknown global entries. */
+    def unknown: Seq[DataEntry]
+    // @formatter:on
+  }
+
+  /** A non-segwit output. */
+  case class NonWitnessOutput(redeemScript: Option[Seq[ScriptElt]],
+                              derivationPaths: Map[PublicKey, KeyPathWithMaster],
+                              unknown: Seq[DataEntry]) extends Output {
+    override val witnessScript: Option[Seq[ScriptElt]] = None
+  }
+
+  /** A segwit output. */
+  case class WitnessOutput(witnessScript: Option[Seq[ScriptElt]],
+                           redeemScript: Option[Seq[ScriptElt]],
+                           derivationPaths: Map[PublicKey, KeyPathWithMaster],
+                           unknown: Seq[DataEntry]) extends Output
+
+  /** An output for which usage of segwit is currently unknown. */
+  case class UnspecifiedOutput(derivationPaths: Map[PublicKey, KeyPathWithMaster], unknown: Seq[DataEntry]) extends Output {
+    override val redeemScript: Option[Seq[ScriptElt]] = None
+    override val witnessScript: Option[Seq[ScriptElt]] = None
   }
 
   /**
@@ -284,63 +581,63 @@ object Psbt {
    */
   def apply(tx: Transaction): Psbt = Psbt(
     Global(Version, tx.copy(txIn = tx.txIn.map(_.copy(signatureScript = ByteVector.empty, witness = ScriptWitness.empty))), Nil, Nil),
-    tx.txIn.map(_ => PartiallySignedInput.empty),
-    tx.txOut.map(_ => PartiallySignedOutput.empty)
+    tx.txIn.map(_ => PartiallySignedInputWithoutUtxo(None, Map.empty, Set.empty, Set.empty, Set.empty, Set.empty, Seq.empty)),
+    tx.txOut.map(_ => UnspecifiedOutput(Map.empty, Seq.empty))
   )
 
-  private def sign(priv: PrivateKey, inputIndex: Int, input: PartiallySignedInput, global: Global): Try[PartiallySignedInput] = {
+  private def sign(priv: PrivateKey, inputIndex: Int, input: Input, global: Global): Try[PartiallySignedInput] = {
     val txIn = global.tx.txIn(inputIndex)
     input match {
-      case PartiallySignedInput(Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _, _) if utxo.txid != txIn.outPoint.txid => Failure(new IllegalArgumentException("non-witness utxo does not match unsigned tx input"))
-      case PartiallySignedInput(Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _, _) if utxo.txOut.length <= txIn.outPoint.index => Failure(new IllegalArgumentException("non-witness utxo index out of bounds"))
-      case PartiallySignedInput(_, Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _) if !Script.isNativeWitnessScript(utxo.publicKeyScript) && !Script.isPayToScript(utxo.publicKeyScript) => Failure(new IllegalArgumentException("witness utxo must use native witness program or P2SH witness program"))
-      case PartiallySignedInput(_, Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _) => signWitness(priv, inputIndex, input, global, utxo)
-      case PartiallySignedInput(Some(utxo), _, _, _, _, _, _, _, _, _, _, _, _, _) => signNonWitness(priv, inputIndex, input, global, utxo)
-      case input => Success(input)
+      case _: PartiallySignedInputWithoutUtxo => Failure(new IllegalArgumentException("cannot sign: input hasn't been updated with utxo data"))
+      case input: PartiallySignedInput if input.nonWitnessUtxo.nonEmpty && input.nonWitnessUtxo.get.txid != txIn.outPoint.txid => Failure(new IllegalArgumentException("non-witness utxo does not match unsigned tx input"))
+      case input: PartiallySignedInput if input.nonWitnessUtxo.nonEmpty && input.nonWitnessUtxo.get.txOut.length <= txIn.outPoint.index => Failure(new IllegalArgumentException("non-witness utxo index out of bounds"))
+      case input: PartiallySignedWitnessInput if !Script.isNativeWitnessScript(input.txOut.publicKeyScript) && !Script.isPayToScript(input.txOut.publicKeyScript) => Failure(new IllegalArgumentException("witness utxo must use native segwit or P2SH embedded segwit"))
+      case input: PartiallySignedWitnessInput => signWitness(priv, inputIndex, input, global)
+      case input: PartiallySignedNonWitnessInput => signNonWitness(priv, inputIndex, input, global)
+      case _: FinalizedInput => Failure(new IllegalArgumentException("cannot sign: input has already been finalized"))
     }
   }
 
-  private def signNonWitness(priv: PrivateKey, inputIndex: Int, input: PartiallySignedInput, global: Global, utxo: Transaction): Try[PartiallySignedInput] = {
+  private def signNonWitness(priv: PrivateKey, inputIndex: Int, input: PartiallySignedNonWitnessInput, global: Global): Try[PartiallySignedInput] = {
     val txIn = global.tx.txIn(inputIndex)
     val redeemScript = input.redeemScript match {
       case Some(script) =>
         // If a redeem script is provided in the partially signed input, the utxo must be a p2sh for that script.
         val p2sh = Script.write(Script.pay2sh(script))
-        if (utxo.txOut(txIn.outPoint.index.toInt).publicKeyScript != p2sh) {
+        if (input.inputTx.txOut(txIn.outPoint.index.toInt).publicKeyScript != p2sh) {
           Failure(new IllegalArgumentException("redeem script does not match non-witness utxo scriptPubKey"))
         } else {
           Success(script)
         }
-      case None => Success(Script.parse(utxo.txOut(txIn.outPoint.index.toInt).publicKeyScript))
+      case None => Success(Script.parse(input.inputTx.txOut(txIn.outPoint.index.toInt).publicKeyScript))
     }
     redeemScript.map(script => {
-      val amount = utxo.txOut(txIn.outPoint.index.toInt).amount
-      val sig = Transaction.signInput(global.tx, inputIndex, script, input.sighashType.getOrElse(SIGHASH_ALL), amount, SigVersion.SIGVERSION_BASE, priv)
+      val sig = Transaction.signInput(global.tx, inputIndex, script, input.sighashType.getOrElse(SIGHASH_ALL), input.amount, SigVersion.SIGVERSION_BASE, priv)
       input.copy(partialSigs = input.partialSigs + (priv.publicKey -> sig))
     })
   }
 
-  private def signWitness(priv: PrivateKey, inputIndex: Int, input: PartiallySignedInput, global: Global, utxo: TxOut): Try[PartiallySignedInput] = {
+  private def signWitness(priv: PrivateKey, inputIndex: Int, input: PartiallySignedWitnessInput, global: Global): Try[PartiallySignedInput] = {
     val redeemScript = input.redeemScript match {
       case Some(script) =>
-        // If a redeem script is provided in the partially signed input, the utxo must be a p2sh for that script.
+        // If a redeem script is provided in the partially signed input, the utxo must be a p2sh for that script (we're using p2sh-embedded segwit).
         val p2sh = Script.write(Script.pay2sh(script))
-        if (utxo.publicKeyScript != p2sh) {
+        if (input.txOut.publicKeyScript != p2sh) {
           Failure(new IllegalArgumentException("redeem script does not match witness utxo scriptPubKey"))
         } else {
           Success(script)
         }
-      case None => Success(Script.parse(utxo.publicKeyScript))
+      case None => Success(Script.parse(input.txOut.publicKeyScript))
     }
     redeemScript.flatMap(script => input.witnessScript match {
       case Some(witnessScript) => if (!Script.isPay2wpkh(script) && script != Script.pay2wsh(witnessScript)) {
         Failure(new IllegalArgumentException("witness script does not match redeemScript or scriptPubKey"))
       } else {
-        val sig = Transaction.signInput(global.tx, inputIndex, witnessScript, input.sighashType.getOrElse(SIGHASH_ALL), utxo.amount, SigVersion.SIGVERSION_WITNESS_V0, priv)
+        val sig = Transaction.signInput(global.tx, inputIndex, witnessScript, input.sighashType.getOrElse(SIGHASH_ALL), input.amount, SigVersion.SIGVERSION_WITNESS_V0, priv)
         Success(input.copy(partialSigs = input.partialSigs + (priv.publicKey -> sig)))
       }
       case None =>
-        val sig = Transaction.signInput(global.tx, inputIndex, script, input.sighashType.getOrElse(SIGHASH_ALL), utxo.amount, SigVersion.SIGVERSION_WITNESS_V0, priv)
+        val sig = Transaction.signInput(global.tx, inputIndex, script, input.sighashType.getOrElse(SIGHASH_ALL), input.amount, SigVersion.SIGVERSION_WITNESS_V0, priv)
         Success(input.copy(partialSigs = input.partialSigs + (priv.publicKey -> sig)))
     })
   }
@@ -357,12 +654,11 @@ object Psbt {
     } else {
       val global = psbts.head.global.copy(
         unknown = combineUnknown(psbts.map(_.global.unknown)),
-        extendedPublicKeys = combineExtendedPublicKeys(psbts.map(_.global.extendedPublicKeys)))
-      Success(Psbt(
-        global,
-        global.tx.txIn.indices.map(i => combineInput(psbts.map(_.inputs(i)))),
-        global.tx.txOut.indices.map(i => combineOutput(psbts.map(_.outputs(i))))
-      ))
+        extendedPublicKeys = combineExtendedPublicKeys(psbts.map(_.global.extendedPublicKeys))
+      )
+      val inputs = global.tx.txIn.indices.map(i => combineInput(global.tx.txIn(i), psbts.map(_.inputs(i))))
+      val outputs = global.tx.txOut.indices.map(i => combineOutput(psbts.map(_.outputs(i))))
+      Success(Psbt(global, inputs, outputs))
     }
   }
 
@@ -372,7 +668,8 @@ object Psbt {
   private def combineExtendedPublicKeys(keys: Seq[Seq[ExtendedPublicKeyWithMaster]]): Seq[ExtendedPublicKeyWithMaster] =
     keys.flatten.map(key => key.extendedPublicKey -> key).toMap.values.toSeq
 
-  private def combineInput(inputs: Seq[PartiallySignedInput]): PartiallySignedInput = PartiallySignedInput(
+  private def combineInput(txIn: TxIn, inputs: Seq[Input]): Input = Codecs.createInput(
+    txIn,
     inputs.flatMap(_.nonWitnessUtxo).headOption,
     inputs.flatMap(_.witnessUtxo).headOption,
     inputs.flatMap(_.sighashType).headOption,
@@ -389,7 +686,7 @@ object Psbt {
     combineUnknown(inputs.map(_.unknown))
   )
 
-  private def combineOutput(outputs: Seq[PartiallySignedOutput]): PartiallySignedOutput = PartiallySignedOutput(
+  private def combineOutput(outputs: Seq[Output]): Output = Codecs.createOutput(
     outputs.flatMap(_.redeemScript).headOption,
     outputs.flatMap(_.witnessScript).headOption,
     outputs.flatMap(_.derivationPaths).toMap,
@@ -423,21 +720,10 @@ object Psbt {
         extendedPublicKeys = psbts.flatMap(_.global.extendedPublicKeys).distinct,
         unknown = psbts.flatMap(_.global.unknown).distinct
       )
-      Success(psbts.head.copy(
-        global = global,
-        inputs = psbts.flatMap(_.inputs),
-        outputs = psbts.flatMap(_.outputs)
-      ))
+      val inputs = psbts.flatMap(_.inputs)
+      val outputs = psbts.flatMap(_.outputs)
+      Success(Psbt(global, inputs, outputs))
     }
-  }
-
-  private def isFinal(in: PartiallySignedInput): Boolean = {
-    // Everything except the utxo, the scriptSigs and unknown keys must be empty.
-    val emptied = in.redeemScript.isEmpty && in.witnessScript.isEmpty && in.partialSigs.isEmpty && in.derivationPaths.isEmpty && in.sighashType.isEmpty
-    // And we must have complete scriptSig for either a witness or non-witness utxo.
-    val hasWitnessData = in.witnessUtxo.nonEmpty && in.scriptWitness.nonEmpty
-    val hasNonWitnessData = in.nonWitnessUtxo.nonEmpty && in.scriptSig.nonEmpty
-    emptied && (hasWitnessData || hasNonWitnessData)
   }
 
   // @formatter:off
@@ -531,9 +817,9 @@ object Psbt {
       } yield Global(version, tx, xpubs, unknown)
     })
 
-    private def readInputs(input: InputStream, txsIn: Seq[TxIn]): Try[Seq[PartiallySignedInput]] = trySequence(txsIn.map(txIn => readInput(input, txIn)))
+    private def readInputs(input: InputStream, txsIn: Seq[TxIn]): Try[Seq[Psbt.Input]] = trySequence(txsIn.map(txIn => readInput(input, txIn)))
 
-    private def readInput(input: InputStream, txIn: TxIn): Try[PartiallySignedInput] = readDataMap(input).flatMap(entries => {
+    private def readInput(input: InputStream, txIn: TxIn): Try[Psbt.Input] = readDataMap(input).flatMap(entries => {
       val keyTypes = Set(0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x0a, 0x0b, 0x0c, 0x0d).map(_.toByte)
       val (known, unknown) = entries.partition(entry => entry.key.headOption.exists(keyTypes.contains))
       val nonWitnessUtxo_opt: Try[Option[Transaction]] = known.find(_.key.head == 0x00).map {
@@ -617,12 +903,40 @@ object Psbt {
         sha256 <- sha256Preimages
         hash160 <- hash160Preimages
         hash256 <- hash256Preimages
-      } yield PartiallySignedInput(nonWitnessUtxo, witnessUtxo, sighashType, partialSigs, derivationPaths, redeemScript, witnessScript, scriptSig, scriptWitness, ripemd160, sha256, hash160, hash256, unknown)
+      } yield createInput(txIn, nonWitnessUtxo, witnessUtxo, sighashType, partialSigs, derivationPaths, redeemScript, witnessScript, scriptSig, scriptWitness, ripemd160, sha256, hash160, hash256, unknown)
     })
 
-    private def readOutputs(input: InputStream, expectedCount: Int): Try[Seq[PartiallySignedOutput]] = trySequence((0 until expectedCount).map(_ => readOutput(input)))
+    def createInput(txIn: TxIn,
+                    nonWitnessUtxo: Option[Transaction],
+                    witnessUtxo: Option[TxOut],
+                    sighashType: Option[Int],
+                    partialSigs: Map[PublicKey, ByteVector],
+                    derivationPaths: Map[PublicKey, KeyPathWithMaster],
+                    redeemScript: Option[Seq[ScriptElt]],
+                    witnessScript: Option[Seq[ScriptElt]],
+                    scriptSig: Option[Seq[ScriptElt]],
+                    scriptWitness: Option[ScriptWitness],
+                    ripemd160: Set[ByteVector],
+                    sha256: Set[ByteVector],
+                    hash160: Set[ByteVector],
+                    hash256: Set[ByteVector],
+                    unknown: Seq[DataEntry]): Psbt.Input = {
+      val emptied = redeemScript.isEmpty && witnessScript.isEmpty && partialSigs.isEmpty && derivationPaths.isEmpty && sighashType.isEmpty
+      (nonWitnessUtxo, witnessUtxo, scriptSig, scriptWitness) match {
+        // If the input is finalized, it must have been emptied otherwise it's invalid.
+        case (_, Some(txOut), _, Some(finalScriptWitness)) if emptied => FinalizedWitnessInput(txOut, nonWitnessUtxo, finalScriptWitness, scriptSig, ripemd160, sha256, hash160, hash256, unknown)
+        case (Some(inputTx), _, Some(finalScriptSig), _) if emptied => FinalizedNonWitnessInput(inputTx, txIn.outPoint.index.toInt, finalScriptSig, ripemd160, sha256, hash160, hash256, unknown)
+        case (_, _, Some(_), _) if emptied => FinalizedInputWithoutUtxo(scriptWitness, scriptSig, ripemd160, sha256, hash160, hash256, unknown)
+        case (_, _, _, Some(_)) if emptied => FinalizedInputWithoutUtxo(scriptWitness, scriptSig, ripemd160, sha256, hash160, hash256, unknown)
+        case (_, Some(txOut), _, _) => PartiallySignedWitnessInput(txOut, nonWitnessUtxo, sighashType, partialSigs, derivationPaths, redeemScript, witnessScript, ripemd160, sha256, hash160, hash256, unknown)
+        case (Some(inputTx), None, _, _) => PartiallySignedNonWitnessInput(inputTx, txIn.outPoint.index.toInt, sighashType, partialSigs, derivationPaths, redeemScript, ripemd160, sha256, hash160, hash256, unknown)
+        case _ => PartiallySignedInputWithoutUtxo(sighashType, derivationPaths, ripemd160, sha256, hash160, hash256, unknown)
+      }
+    }
 
-    private def readOutput(input: InputStream): Try[PartiallySignedOutput] = readDataMap(input).flatMap(entries => {
+    private def readOutputs(input: InputStream, expectedCount: Int): Try[Seq[Psbt.Output]] = trySequence((0 until expectedCount).map(_ => readOutput(input)))
+
+    private def readOutput(input: InputStream): Try[Psbt.Output] = readDataMap(input).flatMap(entries => {
       val keyTypes = Set(0x00, 0x01, 0x02).map(_.toByte)
       val (known, unknown) = entries.partition(entry => entry.key.headOption.exists(keyTypes.contains))
       val redeemScript_opt: Try[Option[Seq[ScriptElt]]] = known.find(_.key.head == 0x00).map {
@@ -646,8 +960,18 @@ object Psbt {
         redeemScript <- redeemScript_opt
         witnessScript <- witnessScript_opt
         derivationPaths <- derivationPaths_opt
-      } yield PartiallySignedOutput(redeemScript, witnessScript, derivationPaths, unknown)
+      } yield createOutput(redeemScript, witnessScript, derivationPaths, unknown)
     })
+
+    def createOutput(redeemScript: Option[Seq[ScriptElt]], witnessScript: Option[Seq[ScriptElt]], derivationPaths: Map[PublicKey, KeyPathWithMaster], unknown: Seq[DataEntry]): Psbt.Output = {
+      if (witnessScript.nonEmpty) {
+        WitnessOutput(witnessScript, redeemScript, derivationPaths, unknown)
+      } else if (redeemScript.nonEmpty) {
+        NonWitnessOutput(redeemScript, derivationPaths, unknown)
+      } else {
+        UnspecifiedOutput(derivationPaths, unknown)
+      }
+    }
 
     @tailrec
     private def readDataMap(input: InputStream, entries: Seq[DataEntry] = Nil): Try[Seq[DataEntry]] = readDataEntry(input) match {
@@ -705,7 +1029,7 @@ object Psbt {
       Protocol.writeUInt8(0x00, output) // separator
     }
 
-    private def writeInputs(inputs: Seq[Psbt.PartiallySignedInput], output: OutputStream): Unit = inputs.foreach(input => {
+    private def writeInputs(inputs: Seq[Psbt.Input], output: OutputStream): Unit = inputs.foreach(input => {
       input.nonWitnessUtxo.foreach(tx => writeDataEntry(DataEntry(hex"00", Transaction.write(tx)), output))
       input.witnessUtxo.foreach(txOut => writeDataEntry(DataEntry(hex"01", TxOut.write(txOut)), output))
       sortPublicKeys(input.partialSigs).foreach { case (publicKey, signature) => writeDataEntry(DataEntry(0x02.toByte +: publicKey.value, signature), output) }
@@ -728,7 +1052,7 @@ object Psbt {
       Protocol.writeUInt8(0x00, output) // separator
     })
 
-    private def writeOutputs(outputs: Seq[Psbt.PartiallySignedOutput], out: OutputStream): Unit = outputs.foreach(output => {
+    private def writeOutputs(outputs: Seq[Psbt.Output], out: OutputStream): Unit = outputs.foreach(output => {
       output.redeemScript.foreach(redeemScript => writeDataEntry(DataEntry(hex"00", Script.write(redeemScript)), out))
       output.witnessScript.foreach(witnessScript => writeDataEntry(DataEntry(hex"01", Script.write(witnessScript)), out))
       sortPublicKeys(output.derivationPaths).foreach {

--- a/src/main/scala/fr/acinq/bitcoin/Script.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Script.scala
@@ -1,10 +1,9 @@
 package fr.acinq.bitcoin
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
-
 import fr.acinq.bitcoin.Crypto._
 import scodec.bits.ByteVector
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
@@ -1109,5 +1108,15 @@ object Script {
    * @return script witness for the corresponding pay-to-witness-public-key-hash script
    */
   def witnessPay2wpkh(pubKey: PublicKey, sig: ByteVector): ScriptWitness = ScriptWitness(sig :: pubKey.value :: Nil)
+
+  /**
+   * @param pubKeys are the public keys signatures will be checked against.
+   * @param sigs    are the signatures for a subset of the public keys.
+   * @return script witness for the pay-to-witness-script-hash script containing a multisig script.
+   */
+  def witnessMultiSigMofN(pubKeys: Seq[PublicKey], sigs: Seq[ByteVector]): ScriptWitness = {
+    val redeemScript = Script.write(Script.createMultiSigMofN(sigs.size, pubKeys))
+    ScriptWitness(ByteVector.empty +: sigs :+ redeemScript)
+  }
 
 }

--- a/src/test/scala/fr/acinq/bitcoin/PsbtSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/PsbtSpec.scala
@@ -2,7 +2,7 @@ package fr.acinq.bitcoin
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.DeterministicWallet.{ExtendedPrivateKey, KeyPath}
-import fr.acinq.bitcoin.Psbt.{KeyPathWithMaster, PartiallySignedOutput}
+import fr.acinq.bitcoin.Psbt._
 import org.scalatest.FunSuite
 import scodec.bits.{ByteVector, HexStringSyntax}
 
@@ -155,7 +155,7 @@ class PsbtSpec extends FunSuite {
       lockTime = 3
     )
     val psbt = Psbt(tx)
-    val Success(updated) = psbt.update(inputTx1, 1, redeemScript = Some(Seq(OP_RETURN))).flatMap(_.update(inputTx2, 0, redeemScript = Some(Seq(OP_RETURN))))
+    val Success(updated) = psbt.updateNonWitnessInput(inputTx1, 1, redeemScript = Some(Seq(OP_RETURN))).flatMap(_.updateNonWitnessInput(inputTx2, 0, redeemScript = Some(Seq(OP_RETURN))))
 
     val outputIndexMismatch = updated.copy(global = updated.global.copy(tx = Transaction(
       version = 2,
@@ -342,7 +342,7 @@ class PsbtSpec extends FunSuite {
       TestCase(
         hex"70736274ff0100a00200000002ab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40000000000feffffffab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40100000000feffffff02603bea0b000000001976a914768a40bbd740cbe81d988e71de2a4d5c71396b1d88ac8e240000000000001976a9146f4620b553fa095e721b9ee0efe9fa039cca459788ac0000000000010122d3dff505000000001976a914d48ed3110b94014cb114bd32d6f4d066dc74256b88ac0001012000e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787010416001485d13537f2e265405a34dbafa9e3dda01fb8230800220202ead596687ca806043edc3de116cdf29d5e9257c196cd055cf698c8d02bf24e9910b4a6ba670000008000000080020000800022020394f62be9df19952c5587768aeb7698061ad2c4a25c894f47d8c162b4d7213d0510b4a6ba6700000080010000800200008000",
         0,
-        "witness utxo must use native witness program or P2SH witness program"
+        "witness utxo must use native segwit or P2SH embedded segwit"
       ),
       // redeemScript with non-witness UTXO does not match the scriptPubKey
       TestCase(
@@ -389,39 +389,52 @@ class PsbtSpec extends FunSuite {
   }
 
   test("update PSBT (official test vectors)") {
+    val firstInputTx = Transaction.read(hex"0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000".toArray)
+    val firstInputIndex = 0
+    val secondInputTx = Transaction.read(hex"0200000000010158e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd7501000000171600145f275f436b09a8cc9a2eb2a2f528485c68a56323feffffff02d8231f1b0100000017a914aed962d6654f9a2b36608eb9d64d2b260db4f1118700c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88702483045022100a22edcc6e5bc511af4cc4ae0de0fcd75c7e04d8c1c3a8aa9d820ed4b967384ec02200642963597b9b1bc22c75e9f3e117284a962188bf5e8a74c895089046a20ad770121035509a48eb623e10aace8bfd0212fdb8a8e5af3c94b0b133b95e114cab89e4f7965000000".toArray)
+    val secondInputIndex = 1
     // Updated PSBT from the previous step.
     val Success(psbt) = Psbt.read(hex"70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f000000000000000000".toArray)
     // Update input 1 with a non-witness multi-sig utxo:
-    val Success(withOneInput) = psbt.update(
-      Transaction.read(hex"0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000".toArray),
-      0,
-      Some(Script.parse(hex"5221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae")),
+    val Success(withOneInput) = psbt.updateNonWitnessInput(
+      firstInputTx,
+      firstInputIndex,
+      Some(Script.createMultiSigMofN(2, Seq(PublicKey(hex"029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f"), PublicKey(hex"02dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d7")))),
       derivationPaths = Map(
         PublicKey(hex"029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/0'")),
         PublicKey(hex"02dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d7") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/1'"))
       ))
     // Update input 2 with a witness multi-sig utxo:
-    val Success(withBothInputs) = withOneInput.update(
-      Transaction.read(hex"0200000000010158e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd7501000000171600145f275f436b09a8cc9a2eb2a2f528485c68a56323feffffff02d8231f1b0100000017a914aed962d6654f9a2b36608eb9d64d2b260db4f1118700c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88702483045022100a22edcc6e5bc511af4cc4ae0de0fcd75c7e04d8c1c3a8aa9d820ed4b967384ec02200642963597b9b1bc22c75e9f3e117284a962188bf5e8a74c895089046a20ad770121035509a48eb623e10aace8bfd0212fdb8a8e5af3c94b0b133b95e114cab89e4f7965000000".toArray),
-      1,
-      Some(Script.parse(hex"00208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b2028903")),
-      Some(Script.parse(hex"522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae")),
+    val Success(withBothInputs) = withOneInput.updateWitnessInput(
+      secondInputTx,
+      secondInputIndex,
+      Some(Script.pay2wsh(Script.createMultiSigMofN(2, Seq(PublicKey(hex"03089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc"), PublicKey(hex"023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e73"))))),
+      Some(Script.createMultiSigMofN(2, Seq(PublicKey(hex"03089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc"), PublicKey(hex"023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e73")))),
       derivationPaths = Map(
         PublicKey(hex"03089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/2'")),
         PublicKey(hex"023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e73") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/3'"))
       ))
     // Update outputs with known derivation paths:
-    val withInputsAndOutputs = withBothInputs.copy(outputs = Seq(
-      psbt.outputs.head.copy(derivationPaths = Map(PublicKey(hex"03a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca58771") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/4'")))),
-      psbt.outputs(1).copy(derivationPaths = Map(PublicKey(hex"027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b50051096") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/5'"))))
-    ))
+    val Success(withInputsAndOutputs) = withBothInputs
+      .updateNonWitnessOutput(0, derivationPaths = Map(PublicKey(hex"03a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca58771") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/4'"))))
+      .flatMap(_.updateWitnessOutput(1, derivationPaths = Map(PublicKey(hex"027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b50051096") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/5'")))))
     // We differ from the official test vector because we include both witnessUtxo and nonWitnessUtxo, because of https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#cite_note-8
     assert(Psbt.write(withInputsAndOutputs) === hex"70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000104475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae2206029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f10d90c6a4f000000800000008000000080220602dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d710d90c6a4f000000800000008001000080000100f80200000000010158e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd7501000000171600145f275f436b09a8cc9a2eb2a2f528485c68a56323feffffff02d8231f1b0100000017a914aed962d6654f9a2b36608eb9d64d2b260db4f1118700c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88702483045022100a22edcc6e5bc511af4cc4ae0de0fcd75c7e04d8c1c3a8aa9d820ed4b967384ec02200642963597b9b1bc22c75e9f3e117284a962188bf5e8a74c895089046a20ad770121035509a48eb623e10aace8bfd0212fdb8a8e5af3c94b0b133b95e114cab89e4f796500000001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88701042200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b2028903010547522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae2206023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7310d90c6a4f000000800000008003000080220603089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc10d90c6a4f00000080000000800200008000220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000".toArray)
     // But if we remove the nonWitnessUtxo in the second input, we match the official test vector:
-    val withOnlyWitnessUtxo = withInputsAndOutputs.copy(inputs = Seq(withInputsAndOutputs.inputs.head, withInputsAndOutputs.inputs(1).copy(nonWitnessUtxo = None)))
+    val withOnlyWitnessUtxo = withInputsAndOutputs.copy(
+      inputs = Seq(withInputsAndOutputs.inputs.head, withInputsAndOutputs.inputs(1).asInstanceOf[PartiallySignedWitnessInput].copy(nonWitnessUtxo = None))
+    )
     assert(Psbt.write(withOnlyWitnessUtxo) === hex"70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000104475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae2206029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f10d90c6a4f000000800000008000000080220602dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d710d90c6a4f0000008000000080010000800001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88701042200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b2028903010547522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae2206023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7310d90c6a4f000000800000008003000080220603089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc10d90c6a4f00000080000000800200008000220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000".toArray)
     // Update inputs to use SIGHASH_ALL:
-    val withSighash = withInputsAndOutputs.copy(inputs = withInputsAndOutputs.inputs.map(_.copy(sighashType = Some(SIGHASH_ALL))))
+    val Success(withSighash) = withInputsAndOutputs.updateNonWitnessInput(
+      firstInputTx,
+      firstInputIndex,
+      sighashType = Some(SIGHASH_ALL)
+    ).flatMap(_.updateWitnessInput(
+      secondInputTx,
+      secondInputIndex,
+      sighashType = Some(SIGHASH_ALL)
+    ))
     assert(Psbt.write(withSighash) === hex"70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000010304010000000104475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae2206029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f10d90c6a4f000000800000008000000080220602dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d710d90c6a4f000000800000008001000080000100f80200000000010158e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd7501000000171600145f275f436b09a8cc9a2eb2a2f528485c68a56323feffffff02d8231f1b0100000017a914aed962d6654f9a2b36608eb9d64d2b260db4f1118700c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88702483045022100a22edcc6e5bc511af4cc4ae0de0fcd75c7e04d8c1c3a8aa9d820ed4b967384ec02200642963597b9b1bc22c75e9f3e117284a962188bf5e8a74c895089046a20ad770121035509a48eb623e10aace8bfd0212fdb8a8e5af3c94b0b133b95e114cab89e4f796500000001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e8870103040100000001042200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b2028903010547522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae2206023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7310d90c6a4f000000800000008003000080220603089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc10d90c6a4f00000080000000800200008000220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000".toArray)
   }
 
@@ -479,23 +492,82 @@ class PsbtSpec extends FunSuite {
     assert(Psbt.write(psbt) === hex"70736274ff01003f0200000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000ffffffff010000000000000000036a0100000000000af00102030405060708090f0102030405060708090a0b0c0d0e0f0af00102030405060708100f0102030405060708090a0b0c0d0e0f000af00102030405060708090f0102030405060708090a0b0c0d0e0f0af00102030405060708100f0102030405060708090a0b0c0d0e0f000af00102030405060708090f0102030405060708090a0b0c0d0e0f0af00102030405060708100f0102030405060708090a0b0c0d0e0f00".toArray)
   }
 
+  test("combine PSBTs") {
+    val inputTx1 = Transaction(2, Nil, TxOut(500 sat, Nil) :: TxOut(1500 sat, Nil) :: TxOut(10000 sat, hex"11223344") :: Nil, 0)
+    val input1 = OutPoint(inputTx1, 2)
+    val inputTx2 = Transaction(2, Nil, TxOut(7500 sat, hex"ff01ee02dd03") :: TxOut(250 sat, Nil) :: Nil, 0)
+    val input2 = OutPoint(inputTx2, 0)
+    val globalTx = Transaction(2, TxIn(input1, Nil, 0) :: TxIn(input2, Nil, 0) :: Nil, TxOut(5000 sat, hex"01020304") :: TxOut(6000 sat, hex"abcdef") :: Nil, 0)
+    val Success(psbt1) = Psbt(globalTx)
+      .updateWitnessInput(inputTx1, 2, None, Some(Seq(OP_1)), Some(SIGHASH_ALL), Map(PublicKey(hex"03089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/2'"))))
+      .flatMap(_.updateNonWitnessInput(inputTx2, 0, Some(Seq(OP_RETURN)), Some(SIGHASH_SINGLE)))
+      .flatMap(_.updateNonWitnessOutput(0, derivationPaths = Map(PublicKey(hex"03a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca58771") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/4'")))))
+    val Success(psbt2) = Psbt(globalTx)
+      .updateNonWitnessInput(inputTx1, 2, Some(Seq(OP_2DROP)), Some(SIGHASH_NONE), Map(PublicKey(hex"02dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d7") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/1'"))))
+      .flatMap(_.updateWitnessInput(inputTx2, 0, None, Some(Seq(OP_8))))
+    val Success(psbt3) = Psbt(globalTx)
+      .updateNonWitnessOutput(0, Some(Seq(OP_DIV)), Map(PublicKey(hex"027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b50051096") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/5'"))))
+      .flatMap(_.updateWitnessOutput(1, Some(Seq(OP_4)), Some(Seq(OP_ADD))))
+    val Success(combined) = Psbt.combine(psbt1, psbt2, psbt3)
+    val expected = Psbt(
+      Global(0, globalTx, Nil, Nil),
+      Seq(
+        PartiallySignedWitnessInput(
+          inputTx1.txOut(2),
+          Some(inputTx1),
+          Some(SIGHASH_ALL),
+          Map.empty,
+          Map(
+            PublicKey(hex"02dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d7") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/1'")),
+            PublicKey(hex"03089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/2'")),
+          ),
+          Some(Seq(OP_2DROP)),
+          Some(Seq(OP_1)),
+          Set.empty, Set.empty, Set.empty, Set.empty, Seq.empty
+        ),
+        PartiallySignedWitnessInput(
+          inputTx2.txOut(0),
+          Some(inputTx2),
+          Some(SIGHASH_SINGLE),
+          Map.empty,
+          Map.empty,
+          Some(Seq(OP_RETURN)),
+          Some(Seq(OP_8)),
+          Set.empty, Set.empty, Set.empty, Set.empty, Seq.empty
+        )
+      ),
+      Seq(
+        NonWitnessOutput(
+          Some(Seq(OP_DIV)),
+          Map(
+            PublicKey(hex"03a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca58771") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/4'")),
+            PublicKey(hex"027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b50051096") -> KeyPathWithMaster(DeterministicWallet.fingerprint(masterPrivKey), KeyPath("m/0'/0'/5'")),
+          ),
+          Seq.empty
+        ),
+        WitnessOutput(Some(Seq(OP_4)), Some(Seq(OP_ADD)), Map.empty, Seq.empty)
+      )
+    )
+    assert(combined === expected)
+  }
+
   test("finalize PSBT (official test vectors)") {
     val Success(psbt) = Psbt.read(hex"70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000002202029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f473044022074018ad4180097b873323c0015720b3684cc8123891048e7dbcd9b55ad679c99022073d369b740e3eb53dcefa33823c8070514ca55a7dd9544f157c167913261118c01220202dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d7483045022100f61038b308dc1da865a34852746f015772934208c6d24454393cd99bdf2217770220056e675a675a6d0a02b85b14e5e29074d8a25a9b5760bea2816f661910a006ea01010304010000000104475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae2206029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f10d90c6a4f000000800000008000000080220602dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d710d90c6a4f0000008000000080010000800001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e887220203089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc473044022062eb7a556107a7c73f45ac4ab5a1dddf6f7075fb1275969a7f383efff784bcb202200c05dbb7470dbf2f08557dd356c7325c1ed30913e996cd3840945db12228da5f012202023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e73473044022065f45ba5998b59a27ffe1a7bed016af1f1f90d54b3aa8f7450aa5f56a25103bd02207f724703ad1edb96680b284b56d4ffcb88f7fb759eabbe08aa30f29b851383d2010103040100000001042200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b2028903010547522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae2206023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7310d90c6a4f000000800000008003000080220603089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc10d90c6a4f00000080000000800200008000220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000".toArray)
-    val finalized0 = {
+    val Success(finalized0) = {
       // The first input is a non-witness 2-of-2 multisig:
       val sig1 = psbt.inputs.head.partialSigs(PublicKey(hex"029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f"))
       val sig2 = psbt.inputs.head.partialSigs(PublicKey(hex"02dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d7"))
       val redeemScript = Script.write(psbt.inputs.head.redeemScript.get)
       val scriptSig = OP_0 :: OP_PUSHDATA(sig1) :: OP_PUSHDATA(sig2) :: OP_PUSHDATA(redeemScript) :: Nil
-      psbt.finalize(0, scriptSig).get
+      psbt.finalizeNonWitnessInput(0, scriptSig)
     }
-    val finalized1 = {
+    val Success(finalized1) = {
       // The second input is a P2SH witness program of a 2-of-2 multisig:
       val sig1 = psbt.inputs(1).partialSigs(PublicKey(hex"03089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc"))
       val sig2 = psbt.inputs(1).partialSigs(PublicKey(hex"023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e73"))
       val witnessScript = Script.write(psbt.inputs(1).witnessScript.get)
       val scriptWitness = ScriptWitness(ByteVector.empty :: sig1 :: sig2 :: witnessScript :: Nil)
-      finalized0.finalize(1, scriptWitness).get
+      finalized0.finalizeWitnessInput(1, scriptWitness)
     }
     assert(Psbt.write(finalized1) === hex"70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000107da00473044022074018ad4180097b873323c0015720b3684cc8123891048e7dbcd9b55ad679c99022073d369b740e3eb53dcefa33823c8070514ca55a7dd9544f157c167913261118c01483045022100f61038b308dc1da865a34852746f015772934208c6d24454393cd99bdf2217770220056e675a675a6d0a02b85b14e5e29074d8a25a9b5760bea2816f661910a006ea01475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae0001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e8870107232200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b20289030108da0400473044022062eb7a556107a7c73f45ac4ab5a1dddf6f7075fb1275969a7f383efff784bcb202200c05dbb7470dbf2f08557dd356c7325c1ed30913e996cd3840945db12228da5f01473044022065f45ba5998b59a27ffe1a7bed016af1f1f90d54b3aa8f7450aa5f56a25103bd02207f724703ad1edb96680b284b56d4ffcb88f7fb759eabbe08aa30f29b851383d20147522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae00220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000".toArray)
   }
@@ -563,20 +635,134 @@ class PsbtSpec extends FunSuite {
     ))
 
     assert(psbt.computeFees().isFailure) // inputs have not been updated yet
-    val Success(oneInput) = psbt.update(inputTx1, 1, witnessScript = Some(Seq(OP_RETURN)))
+    val Success(oneInput) = psbt.updateWitnessInput(inputTx1, 1, witnessScript = Some(Seq(OP_RETURN)))
     assert(oneInput.computeFees().isFailure) // second input has not been updated yet
-    val Success(bothInputs) = oneInput.update(inputTx2, 0, redeemScript = Some(Seq(OP_RETURN)))
+    val Success(bothInputs) = oneInput.updateNonWitnessInput(inputTx2, 0, redeemScript = Some(Seq(OP_RETURN)))
     assert(bothInputs.computeFees() === Success(250 sat))
   }
 
   test("preimage challenges") {
-    val Success(psbt) = Psbt.read(hex"70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f000000000000000000".toArray)
-    val withPreimageChallenges = psbt.copy(inputs = Seq(
-      psbt.inputs.head.copy(ripemd160 = Set(hex"01020304", hex"0102"), hash160 = Set(hex"123456"), hash256 = Set(hex"abcdef", hex"00000000")),
-      psbt.inputs.last.copy(ripemd160 = Set(hex"0102"), sha256 = Set(hex"123456", hex"11"), hash256 = Set(hex"abcdef", hex"00000000"))
-    ))
+    val Success(withPreimageChallenges) = Psbt.read(hex"70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f000000000000000000".toArray)
+      .flatMap(_.updatePreimageChallenges(0, Set(hex"01020304", hex"0102"), Set.empty, Set(hex"123456"), Set(hex"abcdef", hex"00000000")))
+      .flatMap(_.updatePreimageChallenges(1, Set(hex"0102"), Set(hex"123456", hex"11"), Set.empty, Set(hex"abcdef", hex"00000000")))
+    assert(withPreimageChallenges.inputs.head.hash160 === Set(hex"123456"))
+    assert(withPreimageChallenges.inputs.last.sha256 === Set(hex"123456", hex"11"))
     val Success(decoded) = Psbt.read(Psbt.write(withPreimageChallenges))
     assert(decoded === withPreimageChallenges)
+  }
+
+  test("create psbt with various input types") {
+    val masterFingerprint = DeterministicWallet.fingerprint(masterPrivKey)
+    val priv1 = DeterministicWallet.derivePrivateKey(masterPrivKey, KeyPath("m/0'/3'/1'")).privateKey
+    val priv2 = DeterministicWallet.derivePrivateKey(masterPrivKey, KeyPath("m/0'/3'/2'")).privateKey
+    val priv3 = DeterministicWallet.derivePrivateKey(masterPrivKey, KeyPath("m/0'/3'/3'")).privateKey
+    val pubKeys = Seq(priv1, priv2, priv3).map(_.publicKey)
+    val allDerivationPaths = Map(
+      priv1.publicKey -> KeyPathWithMaster(masterFingerprint, KeyPath("m/0'/3'/1'")),
+      priv2.publicKey -> KeyPathWithMaster(masterFingerprint, KeyPath("m/0'/3'/2'")),
+      priv3.publicKey -> KeyPathWithMaster(masterFingerprint, KeyPath("m/0'/3'/3'")),
+    )
+    val inputTx = Transaction(
+      2,
+      Nil,
+      Seq(
+        TxOut(15000 sat, Script.pay2pkh(priv1.publicKey)),
+        TxOut(12000 sat, Script.pay2sh(Script.createMultiSigMofN(2, pubKeys))),
+        TxOut(16000 sat, Script.pay2sh(Script.pay2wpkh(priv2.publicKey))),
+        TxOut(11000 sat, Script.pay2wpkh(priv3.publicKey)),
+        TxOut(13000 sat, Script.pay2wsh(Script.createMultiSigMofN(2, pubKeys))),
+        TxOut(10000 sat, Script.pay2sh(Script.pay2wsh(Script.createMultiSigMofN(1, pubKeys))))
+      ),
+      0
+    )
+    val globalTx = Transaction(
+      2,
+      (0 to 5).map(i => TxIn(OutPoint(inputTx, i), Nil, 0)),
+      Seq(TxOut(60000 sat, Script.pay2wsh(Script.createMultiSigMofN(1, pubKeys.drop(1))))),
+      0
+    )
+    val psbt = Psbt(globalTx)
+    assert(psbt.getInput(2) === Some(PartiallySignedInputWithoutUtxo(None, Map.empty, Set.empty, Set.empty, Set.empty, Set.empty, Seq.empty)))
+    assert(psbt.getInput(6) === None)
+    assert(psbt.getInput(OutPoint(inputTx, 1)) === Some(PartiallySignedInputWithoutUtxo(None, Map.empty, Set.empty, Set.empty, Set.empty, Set.empty, Seq.empty)))
+    assert(psbt.getInput(OutPoint(ByteVector32.Zeroes, 0)) === None)
+
+    // We can't sign the psbt before adding the utxo details (updater role).
+    assert(psbt.sign(priv1, 0).isFailure)
+    assert(psbt.sign(priv3, OutPoint(inputTx, 3)).isFailure)
+
+    // Update all inputs and outputs.
+    val Success(updated) = psbt
+      .updateNonWitnessInput(inputTx, 0, None, Some(SIGHASH_SINGLE | SIGHASH_ANYONECANPAY), Map(priv1.publicKey -> KeyPathWithMaster(masterFingerprint, KeyPath("m/0'/3'/1'"))))
+      .flatMap(_.updateNonWitnessInput(inputTx, 1, Some(Script.createMultiSigMofN(2, pubKeys)), Some(SIGHASH_ALL), allDerivationPaths))
+      .flatMap(_.updateWitnessInput(inputTx, 2, Some(Script.pay2wpkh(priv2.publicKey)), Some(Script.pay2pkh(priv2.publicKey))))
+      .flatMap(_.updateWitnessInput(inputTx, 3, None, Some(Script.pay2pkh(priv3.publicKey)), Some(SIGHASH_SINGLE), Map(priv3.publicKey -> KeyPathWithMaster(masterFingerprint, KeyPath("m/0'/3'/3'")))))
+      .flatMap(_.updateWitnessInput(inputTx, 4, None, Some(Script.createMultiSigMofN(2, pubKeys))))
+      .flatMap(_.updateWitnessInput(inputTx, 5, Some(Script.pay2wsh(Script.createMultiSigMofN(1, pubKeys))), Some(Script.createMultiSigMofN(1, pubKeys))))
+      .flatMap(_.updateWitnessOutput(0, Some(Script.createMultiSigMofN(1, pubKeys.drop(1))), None, allDerivationPaths - priv1.publicKey))
+
+    assert(updated.getInput(0).get.asInstanceOf[PartiallySignedNonWitnessInput].sighashType === Some(SIGHASH_SINGLE | SIGHASH_ANYONECANPAY))
+    assert(updated.getInput(OutPoint(inputTx, 2)).get.asInstanceOf[PartiallySignedWitnessInput].redeemScript === Some(Script.pay2wpkh(priv2.publicKey)))
+    // We reject invalid updates.
+    assert(updated.updateWitnessInput(inputTx, 1, sighashType = Some(SIGHASH_ALL)).isFailure)
+    assert(updated.updateNonWitnessInput(inputTx, 3, derivationPaths = allDerivationPaths).isFailure)
+
+    val Success(signed) = updated
+      .sign(priv1, 0)
+      .flatMap(_.sign(priv1, 1))
+      .flatMap(_.sign(priv2, OutPoint(inputTx, 1)))
+      .flatMap(_.sign(priv2, 2))
+      .flatMap(_.sign(priv3, OutPoint(inputTx, 3)))
+      .flatMap(_.sign(priv2, 4))
+      .flatMap(_.sign(priv3, OutPoint(inputTx, 4)))
+      .flatMap(_.sign(priv2, 5))
+
+    assert(signed.getInput(0).get.partialSigs.size === 1)
+    assert(signed.getInput(OutPoint(inputTx, 4)).get.partialSigs.size === 2)
+    assert(signed.getInput(5).get.partialSigs.size === 1)
+    assert(signed.finalizeWitnessInput(0, ScriptWitness(Seq(priv1.publicKey.value))).isFailure)
+    assert(signed.finalizeNonWitnessInput(3, OP_PUSHDATA(priv1.publicKey) :: Nil).isFailure)
+
+    val scriptSig0 = {
+      val sig = signed.getInput(0).get.partialSigs(priv1.publicKey)
+      OP_PUSHDATA(sig) :: OP_PUSHDATA(priv1.publicKey) :: Nil
+    }
+    val scriptSig1 = {
+      val sig1 = signed.getInput(1).get.partialSigs(priv1.publicKey)
+      val sig2 = signed.getInput(1).get.partialSigs(priv2.publicKey)
+      val redeemScript = Script.write(Script.createMultiSigMofN(2, pubKeys))
+      OP_0 :: OP_PUSHDATA(sig1) :: OP_PUSHDATA(sig2) :: OP_PUSHDATA(redeemScript) :: Nil
+    }
+    val scriptWitness2 = {
+      val sig = signed.getInput(2).get.partialSigs(priv2.publicKey)
+      Script.witnessPay2wpkh(priv2.publicKey, sig)
+    }
+    val scriptWitness3 = {
+      val sig = signed.getInput(3).get.partialSigs(priv3.publicKey)
+      Script.witnessPay2wpkh(priv3.publicKey, sig)
+    }
+    val scriptWitness4 = {
+      val sig1 = signed.getInput(4).get.partialSigs(priv2.publicKey)
+      val sig2 = signed.getInput(4).get.partialSigs(priv3.publicKey)
+      Script.witnessMultiSigMofN(pubKeys, Seq(sig1, sig2))
+    }
+    val scriptWitness5 = {
+      val sig = signed.getInput(5).get.partialSigs(priv2.publicKey)
+      Script.witnessMultiSigMofN(pubKeys, Seq(sig))
+    }
+
+    val Success(finalized) = signed
+      .finalizeNonWitnessInput(0, scriptSig0)
+      .flatMap(_.finalizeNonWitnessInput(1, scriptSig1))
+      .flatMap(_.finalizeWitnessInput(OutPoint(inputTx, 2), scriptWitness2))
+      .flatMap(_.finalizeWitnessInput(3, scriptWitness3))
+      .flatMap(_.finalizeWitnessInput(4, scriptWitness4))
+      .flatMap(_.finalizeWitnessInput(OutPoint(inputTx, 5), scriptWitness5))
+
+    assert(finalized.extract().isSuccess)
+    // Once the psbt is finalized, we reject updates.
+    assert(finalized.sign(priv2, 2).isFailure)
+    assert(finalized.finalizeWitnessInput(3, scriptWitness3).isFailure)
   }
 
   test("bump lightning commit tx fee from cold wallet") {
@@ -595,7 +781,7 @@ class PsbtSpec extends FunSuite {
       val script = anchorScript(fundingPrivKey.publicKey)
       val txToBump = Transaction(2, Nil, Seq(TxOut(330 sat, Script.pay2wsh(script))), 0)
       val Success(lightningPsbt) = Psbt(Transaction(2, Seq(TxIn(OutPoint(txToBump, 0), Nil, 0)), Nil, 0))
-        .update(txToBump, 0, None, Some(script), Some(SIGHASH_NONE | SIGHASH_ANYONECANPAY))
+        .updateWitnessInput(txToBump, 0, None, Some(script), Some(SIGHASH_NONE | SIGHASH_ANYONECANPAY))
         .flatMap(_.sign(fundingPrivKey, 0))
       (fundingPrivKey.publicKey, lightningPsbt)
     }
@@ -604,10 +790,10 @@ class PsbtSpec extends FunSuite {
     val walletPrivKey = PrivateKey(hex"0202020202020202020202020202020202020202020202020202020202020202")
     val confirmedTx = Transaction(2, Nil, Seq(TxOut(100_000 sat, Script.pay2wpkh(walletPrivKey.publicKey))), 0)
     val finalTx_opt = Psbt.join(lightningPsbt, Psbt(Transaction(2, Seq(TxIn(OutPoint(confirmedTx, 0), Nil, 0)), Seq(TxOut(75_000 sat, Script.pay2wpkh(walletPrivKey.publicKey))), 0)))
-      .flatMap(_.update(confirmedTx, 0, None, Some(Script.pay2pkh(walletPrivKey.publicKey))))
+      .flatMap(_.updateWitnessInput(confirmedTx, 0, None, Some(Script.pay2pkh(walletPrivKey.publicKey))))
       .flatMap(_.sign(walletPrivKey, 1))
-      .flatMap(psbt => psbt.finalize(0, ScriptWitness(Seq(psbt.inputs.head.partialSigs(fundingPubKey), Script.write(anchorScript(fundingPubKey))))))
-      .flatMap(psbt => psbt.finalize(1, Script.witnessPay2wpkh(walletPrivKey.publicKey, psbt.inputs(1).partialSigs(walletPrivKey.publicKey))))
+      .flatMap(psbt => psbt.finalizeWitnessInput(0, ScriptWitness(Seq(psbt.inputs.head.partialSigs(fundingPubKey), Script.write(anchorScript(fundingPubKey))))))
+      .flatMap(psbt => psbt.finalizeWitnessInput(1, Script.witnessPay2wpkh(walletPrivKey.publicKey, psbt.inputs(1).partialSigs(walletPrivKey.publicKey))))
       .flatMap(_.extract())
     assert(finalTx_opt.isSuccess)
   }
@@ -618,7 +804,7 @@ class PsbtSpec extends FunSuite {
     psbt.outputs.foreach(output => assert(output.unknown.isEmpty))
   }
 
-  private def verifyEmptyOutput(output: PartiallySignedOutput): Unit = {
+  private def verifyEmptyOutput(output: Psbt.Output): Unit = {
     assert(output.redeemScript === None)
     assert(output.witnessScript === None)
     assert(output.derivationPaths.isEmpty)


### PR DESCRIPTION
Add more structure to PSBT inputs and outputs.
The main change is to split segwit and non-segwit inputs, as they have different requirements.

A higher-level application will always know whether the inputs it's responsible for use segwit or not, so they'll be able to take advantage of these new types (instead of manually parsing the PSBT fields themselves).