### PR TITLE
Get x coordinate of a public key

### DIFF
--- a/src/main/scala/fr/acinq/bitcoin/Crypto.scala
+++ b/src/main/scala/fr/acinq/bitcoin/Crypto.scala
@@ -169,6 +169,9 @@ object Crypto {
 
     // used only if secp256k1 is not available
     lazy val ecpoint = curve.getCurve.decodePoint(value.toArray)
+
+    // x coordinate only
+    def x : ByteVector32 = ByteVector32(value.drop(1))
   }
 
   object PublicKey {


### PR DESCRIPTION
When using Schnorr signature, we only need the x coordinate of the public key.