### PR TITLE
Expose signet support added to bitcoin-kmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,28 +190,28 @@ val sigScript = OP_0 :: OP_PUSHDATA(sig1) :: OP_PUSHDATA(sig2) :: OP_PUSHDATA(re
 This sample demonstrates how to serialize, create and verify a multisig P2SH transaction
 
 ```scala
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
+    val priv1 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1
     val pub1 = priv1.publicKey
-    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.value))
+    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, Crypto.hash160(pub1.value))
 
-    assert(address1 == "D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap")
+    assert(address1 == "mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA")
 
-    val priv2 = PrivateKey.fromBase58("QUpr3G5ia7K7txSq5k7QpgTfNy33iTQWb1nAUgb77xFesn89xsoJ", Base58.Prefix.SecretKeySegnet)._1
+    val priv2 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1
     val pub2 = priv2.publicKey
 
-    val priv3 = PrivateKey.fromBase58("QX3AN7b3WCAFaiCvAS2UD7HJZBsFU6r5shjfogJu55411hAF3BVx", Base58.Prefix.SecretKeySegnet)._1
+    val priv3 = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)._1
     val pub3 = priv3.publicKey
 
-    // this is a standard tx that sends 0.5 BTC to D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap
-    val tx1 = Transaction.read("010000000240b4f27534e9d5529e67e52619c7addc88eff64c8e7afc9b41afe9a01c6e2aea010000006b48304502210091aed7fe956c4b2471778bfef5a323a96fee21ec6d73a9b7f363beaad135c5f302207f63b0ffc08fd905cdb87b109416c2d6d8ec56ca25dd52529c931aa1154277f30121037cb5789f1ca6c640b6d423ef71390e0b002da81db8fad4466bf6c2fdfb79a24cfeffffff6e21b8c625d9955e48de0a6bbcd57b03624620a93536ddacabc19d024c330f04010000006a47304402203fb779df3ae2bf8404e6d89f83af3adee0d0a0c4ec5a01a1e88b3aa4313df6490220608177ca82cf4f7da9820a8e8bf4266ccece9eb004e73926e414296d0635d7c1012102edc343e7c422e94cca4c2a87a4f7ce54594c1b68682bbeefa130295e471ac019feffffff0280f0fa02000000001976a9140f66351d05269952302a607b4d6fb69517387a9788ace06d9800000000001976a91457572594090c298721e8dddcec3ac1ec593c6dcc88ac205a0000", pversion)
+    // this is a standard tx that sends 0.05 BTC to mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA
+    val tx1 = Transaction.read("020000000001016ecc08b535a0c774234419dee508867ace1535a0d256d6b2aa19942441777336000000002322002073bb471aa121fbdd95942eabb5e665d66e71542e6e075c8392cd0df72a075b72fdffffff02803823030000000017a914d3c15be7951c9de644bdf9e22dcbcb77550c4ae487404b4c00000000001976a9143545b2a6659dbe5bdf841d1158135be184d81d3688ac0400473044022041cac92405e4e3215c2f9c27a67ff0792c8fb76e4182023fed081f541f4563e002203bd04d4d810ef8074aeb26a19e01e1ee1a40ad83e4d0ac2c614b8cb22825d2ae0147304402204c947b46ea480419c04098a56a5219bb1f491b07e12926fb6f304132a1f1e29e022078cc9f004c74d6c3c2b2dfcca6385d2fabe44d4eadb027a0d764e1ab9d7f09190147522102be608bf8904326b4d0ec9346aa348773fe51ee70338849acd2dd710b73bf611a2103627c19e40f67c5ee8b44df85ee911b7e978869fa5a3de1d972a461f47ea349e452ae90bb2300", pversion)
 
-    // now let's create a simple tx that spends tx1 and send 0.5 BTC to a P2WSH output
+    // now let's create a simple tx that spends tx1 and send 0.049 BTC to a P2WSH output
     val tx2 = {
       // our script is a 2-of-2 multisig script
       val redeemScript = Script.createMultiSigMofN(2, Seq(pub2, pub3))
       val tmp = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx1.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.49 btc, Script.pay2wsh(redeemScript)) :: Nil,
+        txOut = TxOut(0.049 btc, Script.pay2wsh(redeemScript)) :: Nil,
         lockTime = 0
       )
       val sig = Transaction.signInput(tmp, 0, tx1.txOut(0).publicKeyScript, SIGHASH_ALL, 0 sat, SigVersion.SIGVERSION_BASE, priv1)
@@ -219,14 +219,14 @@ This sample demonstrates how to serialize, create and verify a multisig P2SH tra
       //Transaction.sign(tmp, Seq(SignData(tx1.txOut(0).publicKeyScript, priv1)))
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx2.txid == ByteVector32(hex"9d896b6d2b8fc9665da72f5b1942f924a37c5c714f31f40ee2a6c945f74dd355"))
-    // this tx was published on segnet as 9d896b6d2b8fc9665da72f5b1942f924a37c5c714f31f40ee2a6c945f74dd355
+    assert(tx2.txid == ByteVector32(hex"2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9"))
+    // this tx was published on testnet as 2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9
 
-    // and now we create a segwit tx that spends the P2WSH output
+    // and now we create a testnet tx that spends the P2WSH output
     val tx3 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx2.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.48 btc, Script.pay2wpkh(pub1)) :: Nil,
+        txOut = TxOut(0.048 btc, Script.pay2wpkh(pub1)) :: Nil,
         lockTime = 0
       )
       val pubKeyScript = Script.write(Script.createMultiSigMofN(2, Seq(pub2, pub3)))
@@ -237,8 +237,8 @@ This sample demonstrates how to serialize, create and verify a multisig P2SH tra
     }
 
     Transaction.correctlySpends(tx3, Seq(tx2), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx3.txid == ByteVector32(hex"943e07f0c66a9766d0cec81d65a03db4157bc0bfac4d36e400521b947be55aeb"))
-    // this tx was published on segnet as 943e07f0c66a9766d0cec81d65a03db4157bc0bfac4d36e400521b947be55aeb
+    assert(tx3.txid == ByteVector32(hex"4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a"))
+    // this tx was published on testnet as 4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a
 ```
 
 #### P2WPKH transactions
@@ -259,16 +259,16 @@ val witness = ScriptWitness(sig :: pubKey :: Nil))
 This sample demonstrates how to serialize, create and verify a P2WPKH transaction
 
 ```scala
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
+    val priv1 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1
     val pub1 = priv1.publicKey
-    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.value))
+    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, Crypto.hash160(pub1.value))
 
-    assert(address1 == "D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap")
+    assert(address1 == "mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA")
 
-    // this is a standard tx that sends 0.4 BTC to D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap
-    val tx1 = Transaction.read("010000000001014d5a1833ddd78613408d66b0189e3171aa3b5d1a5b2df4392749d39291ea73cd0000000000feffffff02005a6202000000001976a9140f66351d05269952302a607b4d6fb69517387a9788ac048b9800000000001976a914eb7c97a96fa9205b8a772d0c1d170e90a8a3098388ac02483045022100e2ccc1ab7e7e0c6bcbbdd4d9935448011b415fc1ec774416aa2760c3ae08431d022064ad6fd7c952df2b3f06a9cf94ddc9856c734c46ad43d0ab45d5ddf3b7deeef0012102edc343e7c422e94cca4c2a87a4f7ce54594c1b68682bbeefa130295e471ac019ae590000", pversion)
+    // this is a standard tx that sends 0.04 BTC to mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA
+    val tx1 = Transaction.read("02000000000101516508384a3e006340f1ea700eb3635330beed5d94c7b460b6b495eb1593d55c0100000023220020a5fdf5b5f2c592362b78a50997821964b39dd90476c6e1f3e97e79acb134ca3bfdffffff0200093d00000000001976a9145dbf52b8d7af4fb5f9b75b808f0a8284493531b388aca005071d0000000017a914d77e5f7ca4d9f05dc4f25dc0aa1391f0e901bdfc87040047304402207bfb18327be173512f38bd4120b8f02545321ecc6105a852cbc25b1de687ba570220705a1225d8a8e0fbd4b35f3bc38a2840706f8524e8dc6f0151746aeff14033ce014730440220486925fb0495442e4ccb1b711692af7057d4db24f8775b5dfa3f8c74992081f102203beae7d96423e0c66b7b5f8919a5f3ad89a42dc4303f37201e4e596909478357014752210245119449d07c16992c148e3b33f1395ee05c936fc510d9fae83417f8e1901f922103eb03f67b56c88bccff90b76182c08556eac9ebc5a0efee8669bef69ae6d4ea5752ae75bb2300", pversion)
 
-    // now let's create a simple tx that spends tx1 and send 0.39 BTC to P2WPKH output
+    // now let's create a simple tx that spends tx1 and send 0.039 BTC to P2WPKH output
     val tx2 = {
       val tmp = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx1.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty, witness = ScriptWitness.empty) :: Nil,
@@ -279,14 +279,14 @@ This sample demonstrates how to serialize, create and verify a P2WPKH transactio
       tmp.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(priv1.publicKey) :: Nil)
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx2.txid == ByteVector32(hex"3acf933cd1dbffbb81bb5c6fab816fdebf85875a3b77754a28f00d717f450e1e"))
-    // this tx was published on segnet as 3acf933cd1dbffbb81bb5c6fab816fdebf85875a3b77754a28f00d717f450e1e
+    assert(tx2.txid == ByteVector32(hex"f25b3fecc9652466926237d96e4bc7ee2c984051fe48e61417aba218af5570c3"))
+    // this tx was published on testnet as f25b3fecc9652466926237d96e4bc7ee2c984051fe48e61417aba218af5570c3
 
     // and now we create a segwit tx that spends the P2WPKH output
     val tx3 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx2.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty, witness = ScriptWitness.empty) :: Nil,
-        txOut = TxOut(0.38 btc, Script.pay2wpkh(pub1)) :: Nil, // we reuse the same output script but if could be anything else
+        txOut = TxOut(0.038 btc, Script.pay2wpkh(pub1)) :: Nil, // we reuse the same output script but if could be anything else
         lockTime = 0
       )
       // mind this: the pubkey script used for signing is not the prevout pubscript (which is just a push
@@ -298,8 +298,8 @@ This sample demonstrates how to serialize, create and verify a P2WPKH transactio
     }
 
     Transaction.correctlySpends(tx3, Seq(tx2), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx3.txid == ByteVector32(hex"a474219df20b95210b8dac45bb5ed49f0979f8d9b6c17420f3e50f6abc071af8"))
-    // this tx was published on segnet as a474219df20b95210b8dac45bb5ed49f0979f8d9b6c17420f3e50f6abc071af8
+    assert(tx3.txid == ByteVector32(hex"739e7cba97af259d2c089690adea00aa78b1c8d7995aa9377be58fe5332378aa"))
+    // this tx was published on testnet as 739e7cba97af259d2c089690adea00aa78b1c8d7995aa9377be58fe5332378aa
 ```
 
 #### P2WSH transactions
@@ -321,28 +321,28 @@ val witness = ScriptWitness(Seq(ByteVector.empty, sig2, sig3, redeemScript))
 This sample demonstrates how to serialize, create and verify a P2WSH transaction
 
 ```scala
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
+    val priv1 = PrivateKey.fromBase58("cV5oyXUgySSMcUvKNdKtuYg4t4NTaxkwYrrocgsJZuYac2ogEdZX", Base58.Prefix.SecretKeyTestnet)._1
     val pub1 = priv1.publicKey
-    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.value))
+    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, Crypto.hash160(pub1.value))
 
-    assert(address1 == "D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap")
+    assert(address1 == "mkNdbutRYE3me7wvbwvvJ8XQwbzi56sneZ")
 
-    val priv2 = PrivateKey.fromBase58("QUpr3G5ia7K7txSq5k7QpgTfNy33iTQWb1nAUgb77xFesn89xsoJ", Base58.Prefix.SecretKeySegnet)._1
+    val priv2 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1
     val pub2 = priv2.publicKey
 
-    val priv3 = PrivateKey.fromBase58("QX3AN7b3WCAFaiCvAS2UD7HJZBsFU6r5shjfogJu55411hAF3BVx", Base58.Prefix.SecretKeySegnet)._1
+    val priv3 = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)._1
     val pub3 = priv3.publicKey
 
-    // this is a standard tx that sends 0.5 BTC to D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap
-    val tx1 = Transaction.read("010000000240b4f27534e9d5529e67e52619c7addc88eff64c8e7afc9b41afe9a01c6e2aea010000006b48304502210091aed7fe956c4b2471778bfef5a323a96fee21ec6d73a9b7f363beaad135c5f302207f63b0ffc08fd905cdb87b109416c2d6d8ec56ca25dd52529c931aa1154277f30121037cb5789f1ca6c640b6d423ef71390e0b002da81db8fad4466bf6c2fdfb79a24cfeffffff6e21b8c625d9955e48de0a6bbcd57b03624620a93536ddacabc19d024c330f04010000006a47304402203fb779df3ae2bf8404e6d89f83af3adee0d0a0c4ec5a01a1e88b3aa4313df6490220608177ca82cf4f7da9820a8e8bf4266ccece9eb004e73926e414296d0635d7c1012102edc343e7c422e94cca4c2a87a4f7ce54594c1b68682bbeefa130295e471ac019feffffff0280f0fa02000000001976a9140f66351d05269952302a607b4d6fb69517387a9788ace06d9800000000001976a91457572594090c298721e8dddcec3ac1ec593c6dcc88ac205a0000", pversion)
+    // this is a standard tx that sends 0.05 BTC to mkNdbutRYE3me7wvbwvvJ8XQwbzi56sneZ
+    val tx1 = Transaction.read("020000000001016ecc08b535a0c774234419dee508867ace1535a0d256d6b2aa19942441777336000000002322002073bb471aa121fbdd95942eabb5e665d66e71542e6e075c8392cd0df72a075b72fdffffff02803823030000000017a914d3c15be7951c9de644bdf9e22dcbcb77550c4ae487404b4c00000000001976a9143545b2a6659dbe5bdf841d1158135be184d81d3688ac0400473044022041cac92405e4e3215c2f9c27a67ff0792c8fb76e4182023fed081f541f4563e002203bd04d4d810ef8074aeb26a19e01e1ee1a40ad83e4d0ac2c614b8cb22825d2ae0147304402204c947b46ea480419c04098a56a5219bb1f491b07e12926fb6f304132a1f1e29e022078cc9f004c74d6c3c2b2dfcca6385d2fabe44d4eadb027a0d764e1ab9d7f09190147522102be608bf8904326b4d0ec9346aa348773fe51ee70338849acd2dd710b73bf611a2103627c19e40f67c5ee8b44df85ee911b7e978869fa5a3de1d972a461f47ea349e452ae90bb2300", pversion)
 
-    // now let's create a simple tx that spends tx1 and send 0.5 BTC to a P2WSH output
+    // now let's create a simple tx that spends tx1 and sends 0.049 BTC to a P2WSH output
     val tx2 = {
       // our script is a 2-of-2 multisig script
       val redeemScript = Script.createMultiSigMofN(2, Seq(pub2, pub3))
       val tmp = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx1.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.49 btc, Script.pay2wsh(redeemScript)) :: Nil,
+        txOut = TxOut(0.049 btc, Script.pay2wsh(redeemScript)) :: Nil,
         lockTime = 0
       )
       val sig = Transaction.signInput(tmp, 0, tx1.txOut(0).publicKeyScript, SIGHASH_ALL, 0 sat, SigVersion.SIGVERSION_BASE, priv1)
@@ -350,14 +350,14 @@ This sample demonstrates how to serialize, create and verify a P2WSH transaction
       //Transaction.sign(tmp, Seq(SignData(tx1.txOut(0).publicKeyScript, priv1)))
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx2.txid == ByteVector32(hex"9d896b6d2b8fc9665da72f5b1942f924a37c5c714f31f40ee2a6c945f74dd355"))
-    // this tx was published on segnet as 9d896b6d2b8fc9665da72f5b1942f924a37c5c714f31f40ee2a6c945f74dd355
+    assert(tx2.txid == ByteVector32(hex"2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9"))
+    // this tx was published on testnet as 2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9
 
     // and now we create a segwit tx that spends the P2WSH output
     val tx3 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx2.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.48 btc, Script.pay2wpkh(pub1)) :: Nil,
+        txOut = TxOut(0.048 btc, Script.pay2wpkh(pub1)) :: Nil,
         lockTime = 0
       )
       val pubKeyScript = Script.write(Script.createMultiSigMofN(2, Seq(pub2, pub3)))
@@ -368,32 +368,32 @@ This sample demonstrates how to serialize, create and verify a P2WSH transaction
     }
 
     Transaction.correctlySpends(tx3, Seq(tx2), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx3.txid == ByteVector32(hex"943e07f0c66a9766d0cec81d65a03db4157bc0bfac4d36e400521b947be55aeb"))
-    // this tx was published on segnet as 943e07f0c66a9766d0cec81d65a03db4157bc0bfac4d36e400521b947be55aeb
+    assert(tx3.txid == ByteVector32(hex"4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a"))
+    // this tx was published on testnet as 4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a
 ```
 
 #### Segwit transactions embedded in standard P2SH transactions
 
 ```scala
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
+    val priv1 = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)._1
     val pub1 = priv1.publicKey
 
     // p2wpkh script
     val script = Script.write(Script.pay2wpkh(pub1))
 
     // which we embeed into a standard p2sh script
-    val p2shaddress = Base58Check.encode(Base58.Prefix.ScriptAddressSegnet, Crypto.hash160(script))
-    assert(p2shaddress === "MDbNMghDbaaizHz8pSgMqu9qJXvKwouqkM")
+    val p2shaddress = Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script))
+    assert(p2shaddress === "2NB3GUVxBF3P7NLMkSGNai33mWkM35ht1Xj")
 
     // this tx send 0.5 btc to our p2shaddress
-    val tx = Transaction.read("010000000175dd435bf25e5d77567272f7d6eefcf37b7156b78bb233490140d6fa7545cfca010000006a47304402206e601a482b301141cb3a1712c18729fa1f1731fce5c4205ac9d344af38bb24bf022003fe70edcbd1a5b3957b3c939e583739eadb8de8d3d2cc2ad2903b19c991cb80012102ba2558223d7cd5df2d8decc4506a62ccaa96159f685360335c280952b25e7adefeffffff02692184df000000001976a9148b3ee15d631122010d31e1774aa318ca9ca8b67088ac80f0fa020000000017a9143e73638f202bb880a28e8df1946adc3058227d11878c730000", pversion)
+    val tx = Transaction.read("02000000000101d9ee0034f9ae4fac7a4017d78e26e1c492d507e16f3535ecbc2ea72cb1c4c6f501000000232200208a15b02dab825f2a4b60b58a7c8591c659a3eb18765fd9d926332c0cea574e2ffdffffff02d292e4000000000017a914aefbc2c20e0c312a616cf7c4ebbacc5c9a04432787404b4c000000000017a914c32f5922344dbe1abd4fb1744b560b5d1875353987040047304402205fbba2ab917efc23209fe04086fb5f714e527d088e2a5ec19590ec4b566a8c2d02206607f3e42eaff5d30dd6297dcb4d48300a75819a358c0bc20396e393ab1594260147304402206a0df35cb8fc58fb21b111d432abc7f9f74836ad1e35c63be2f0c772d4a2ce49022076c4c96a7a9d18577a5e762a3dc3e4b728fd950284c133eb3147707b9181f90b01475221039c40944fe4f90f46760621a1ca66d3141f7e81ccccfa2cf4550fdb9b432c52ed2102976af59e7b61fb3c7a6a2553d7b030a5e292fdda6eba439b4a24af494b3475c752aebebb2300", pversion)
 
     // let's spend it:
 
     val tx1 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx.hash, 1), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.49 btc, OP_0 :: OP_PUSHDATA(Crypto.hash160(pub1.value)) :: Nil) :: Nil,
+        txOut = TxOut(0.049 btc, OP_0 :: OP_PUSHDATA(Crypto.hash160(pub1.value)) :: Nil) :: Nil,
         lockTime = 0
       )
       val pubKeyScript = Script.pay2pkh(pub1)
@@ -403,8 +403,8 @@ This sample demonstrates how to serialize, create and verify a P2WSH transaction
     }
 
     Transaction.correctlySpends(tx1, Seq(tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx1.txid === ByteVector32(hex"98f5668176b0c1b14653f96f71987fd325c3d46b9efb677ab0606ea5555791d5"))
-    // this tx was published on segnet as 98f5668176b0c1b14653f96f71987fd325c3d46b9efb677ab0606ea5555791d5
+    assert(tx1.txid === ByteVector32(hex"4807cb10f50df84acd7766245133f902d22d91b7e8bfe77c4bbcb0cf9b017a86"))
+    // this tx was published on testnet as 4807cb10f50df84acd7766245133f902d22d91b7e8bfe77c4bbcb0cf9b017a86
 ```
 
 ### Wallet features

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>fr.acinq.bitcoin</groupId>
             <artifactId>bitcoin-kmp-jvm</artifactId>
-            <version>0.8.4</version>
+            <version>0.8.5</version>
         </dependency>
         <dependency>
             <groupId>fr.acinq.secp256k1</groupId>

--- a/src/main/scala/fr/acinq/bitcoin/scalacompat/Block.scala
+++ b/src/main/scala/fr/acinq/bitcoin/scalacompat/Block.scala
@@ -19,11 +19,6 @@ object Block {
     val hash: ByteVector32 = fr.acinq.bitcoin.Block.RegtestGenesisBlock.hash
   }
 
-  object SegnetGenesisBlock {
-    val blockId: ByteVector32 = fr.acinq.bitcoin.Block.SegnetGenesisBlock.blockId
-    val hash: ByteVector32 = fr.acinq.bitcoin.Block.SegnetGenesisBlock.hash
-  }
-
   object SignetGenesisBlock {
     val blockId: ByteVector32 = fr.acinq.bitcoin.Block.SignetGenesisBlock.blockId
     val hash: ByteVector32 = fr.acinq.bitcoin.Block.SignetGenesisBlock.hash

--- a/src/main/scala/fr/acinq/bitcoin/scalacompat/Block.scala
+++ b/src/main/scala/fr/acinq/bitcoin/scalacompat/Block.scala
@@ -23,4 +23,9 @@ object Block {
     val blockId: ByteVector32 = fr.acinq.bitcoin.Block.SegnetGenesisBlock.blockId
     val hash: ByteVector32 = fr.acinq.bitcoin.Block.SegnetGenesisBlock.hash
   }
+
+  object SignetGenesisBlock {
+    val blockId: ByteVector32 = fr.acinq.bitcoin.Block.SignetGenesisBlock.blockId
+    val hash: ByteVector32 = fr.acinq.bitcoin.Block.SignetGenesisBlock.hash
+  }
 }

--- a/src/test/scala/fr/acinq/bitcoin/scalacompat/SegwitSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/scalacompat/SegwitSpec.scala
@@ -85,9 +85,9 @@ class SegwitSpec extends FunSuite {
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     assert(tx2.txid == ByteVector32(hex"f25b3fecc9652466926237d96e4bc7ee2c984051fe48e61417aba218af5570c3"))
-    // this tx was published on segnet as f25b3fecc9652466926237d96e4bc7ee2c984051fe48e61417aba218af5570c3
+    // this tx was published on testnet as f25b3fecc9652466926237d96e4bc7ee2c984051fe48e61417aba218af5570c3
 
-    // and now we create a segwit tx that spends the P2WPK output
+    // and now we create a testnet tx that spends the P2WPK output
     val tx3 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx2.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty, witness = ScriptWitness.empty) :: Nil,
@@ -104,7 +104,7 @@ class SegwitSpec extends FunSuite {
 
     Transaction.correctlySpends(tx3, Seq(tx2), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     assert(tx3.txid == ByteVector32(hex"739e7cba97af259d2c089690adea00aa78b1c8d7995aa9377be58fe5332378aa"))
-    // this tx was published on segnet as 739e7cba97af259d2c089690adea00aa78b1c8d7995aa9377be58fe5332378aa
+    // this tx was published on testnet as 739e7cba97af259d2c089690adea00aa78b1c8d7995aa9377be58fe5332378aa
   }
 
   test("create p2wsh tx") {
@@ -138,9 +138,9 @@ class SegwitSpec extends FunSuite {
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     assert(tx2.txid == ByteVector32(hex"2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9"))
-    // this tx was published on segnet as 2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9
+    // this tx was published on testnet as 2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9
 
-    // and now we create a segwit tx that spends the P2WSH output
+    // and now we create a testnet tx that spends the P2WSH output
     val tx3 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx2.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
@@ -156,7 +156,7 @@ class SegwitSpec extends FunSuite {
 
     Transaction.correctlySpends(tx3, Seq(tx2), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     assert(tx3.txid == ByteVector32(hex"4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a"))
-    // this tx was published on segnet as 4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a
+    // this tx was published on testnet as 4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a
   }
 
   test("create p2pkh embedded in p2sh") {
@@ -189,6 +189,6 @@ class SegwitSpec extends FunSuite {
 
     Transaction.correctlySpends(tx1, Seq(tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     assert(tx1.txid === ByteVector32(hex"4807cb10f50df84acd7766245133f902d22d91b7e8bfe77c4bbcb0cf9b017a86"))
-    // this tx was published on segnet as 4807cb10f50df84acd7766245133f902d22d91b7e8bfe77c4bbcb0cf9b017a86
+    // this tx was published on testnet as 4807cb10f50df84acd7766245133f902d22d91b7e8bfe77c4bbcb0cf9b017a86
   }
 }

--- a/src/test/scala/fr/acinq/bitcoin/scalacompat/SegwitSpec.scala
+++ b/src/test/scala/fr/acinq/bitcoin/scalacompat/SegwitSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 import scodec.bits._
 
 class SegwitSpec extends FunSuite {
-  val pversion = Protocol.PROTOCOL_VERSION
+  val pversion: Int = Protocol.PROTOCOL_VERSION
 
   test("tx serialization with witness") {
     // see https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#Example
@@ -44,14 +44,14 @@ class SegwitSpec extends FunSuite {
     val priv = PrivateKey(hex"619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb901")
     val pub = priv.publicKey
     val pubKeyScript = Script.write(Script.pay2wpkh(pub))
-    val runner = new Script.Runner(new Script.Context(tx, 1, 600000000 sat), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    val runner = new Script.Runner(Script.Context(tx, 1, 600000000 sat), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     assert(runner.verifyScripts(tx.txIn(1).signatureScript, pubKeyScript, tx.txIn(1).witness))
   }
 
   test("segwit fixes tx malleability") {
     val tx1 = Transaction.read("010000000001011e0e457f710df0284a75773b5a8785bfde6f81ab6f5cbb81bbffdbd13c93cf3a0000000000ffffffff0180d54302000000001600140f66351d05269952302a607b4d6fb69517387a9702483045022100d1fe26c7e00b37b833c3973e7394d82d09934670e7d3995f6d8584dd7ef113930220700b4ce9195ddc086b0eaceb0cf7f7f1c89c8f6a5b1c11c7c8c02f4b3d0612ab012102edc343e7c422e94cca4c2a87a4f7ce54594c1b68682bbeefa130295e471ac01900000000", pversion)
     assert(tx1.hasWitness)
-    assert(tx1.txIn.find(!_.signatureScript.isEmpty).isEmpty)
+    assert(tx1.txIn.forall(_.signatureScript.isEmpty))
     val tx2 = tx1.updateWitnesses(Seq(ScriptWitness.empty))
     assert(tx2 != tx1)
     assert(tx2.txid == tx1.txid)
@@ -64,34 +64,34 @@ class SegwitSpec extends FunSuite {
   }
 
   test("create p2wpkh tx") {
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
+    val priv1 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1
     val pub1 = priv1.publicKey
-    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.value).toArray)
+    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, Crypto.hash160(pub1.value).toArray)
 
-    assert(address1 == "D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap")
+    assert(address1 == "mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA")
 
-    // this is a standard tx that sends 0.4 BTC to D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap
-    val tx1 = Transaction.read("010000000001014d5a1833ddd78613408d66b0189e3171aa3b5d1a5b2df4392749d39291ea73cd0000000000feffffff02005a6202000000001976a9140f66351d05269952302a607b4d6fb69517387a9788ac048b9800000000001976a914eb7c97a96fa9205b8a772d0c1d170e90a8a3098388ac02483045022100e2ccc1ab7e7e0c6bcbbdd4d9935448011b415fc1ec774416aa2760c3ae08431d022064ad6fd7c952df2b3f06a9cf94ddc9856c734c46ad43d0ab45d5ddf3b7deeef0012102edc343e7c422e94cca4c2a87a4f7ce54594c1b68682bbeefa130295e471ac019ae590000", pversion)
+    // this is a standard tx that sends 0.04 BTC to mp4eLFx7CpifAJxnvCZ3FmqKsh9dQmi5dA
+    val tx1 = Transaction.read("02000000000101516508384a3e006340f1ea700eb3635330beed5d94c7b460b6b495eb1593d55c0100000023220020a5fdf5b5f2c592362b78a50997821964b39dd90476c6e1f3e97e79acb134ca3bfdffffff0200093d00000000001976a9145dbf52b8d7af4fb5f9b75b808f0a8284493531b388aca005071d0000000017a914d77e5f7ca4d9f05dc4f25dc0aa1391f0e901bdfc87040047304402207bfb18327be173512f38bd4120b8f02545321ecc6105a852cbc25b1de687ba570220705a1225d8a8e0fbd4b35f3bc38a2840706f8524e8dc6f0151746aeff14033ce014730440220486925fb0495442e4ccb1b711692af7057d4db24f8775b5dfa3f8c74992081f102203beae7d96423e0c66b7b5f8919a5f3ad89a42dc4303f37201e4e596909478357014752210245119449d07c16992c148e3b33f1395ee05c936fc510d9fae83417f8e1901f922103eb03f67b56c88bccff90b76182c08556eac9ebc5a0efee8669bef69ae6d4ea5752ae75bb2300", pversion)
 
-    // now let's create a simple tx that spends tx1 and send 0.39 BTC to P2WPK output
+    // now let's create a simple tx that spends tx1 and send 0.039 BTC to P2WPK output
     val tx2 = {
       val tmp = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx1.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty, witness = ScriptWitness.empty) :: Nil,
-        txOut = TxOut(0.39 btc, Script.pay2wpkh(pub1)) :: Nil,
+        txOut = TxOut(0.039 btc, Script.pay2wpkh(pub1)) :: Nil,
         lockTime = 0
       )
       val sig = Transaction.signInput(tmp, 0, tx1.txOut(0).publicKeyScript, SigHash.SIGHASH_ALL, 0 sat, SigVersion.SIGVERSION_BASE, priv1)
       tmp.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(priv1.publicKey) :: Nil)
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx2.txid == ByteVector32(hex"3acf933cd1dbffbb81bb5c6fab816fdebf85875a3b77754a28f00d717f450e1e"))
-    // this tx was published on segnet as 3acf933cd1dbffbb81bb5c6fab816fdebf85875a3b77754a28f00d717f450e1e
+    assert(tx2.txid == ByteVector32(hex"f25b3fecc9652466926237d96e4bc7ee2c984051fe48e61417aba218af5570c3"))
+    // this tx was published on segnet as f25b3fecc9652466926237d96e4bc7ee2c984051fe48e61417aba218af5570c3
 
     // and now we create a segwit tx that spends the P2WPK output
     val tx3 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx2.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty, witness = ScriptWitness.empty) :: Nil,
-        txOut = TxOut(0.38 btc, Script.pay2wpkh(pub1)) :: Nil, // we reuse the same output script but if could be anything else
+        txOut = TxOut(0.038 btc, Script.pay2wpkh(pub1)) :: Nil, // we reuse the same output script but if could be anything else
         lockTime = 0
       )
       // mind this: the pubkey script used for signing is not the prevout pubscript (which is just a push
@@ -103,48 +103,48 @@ class SegwitSpec extends FunSuite {
     }
 
     Transaction.correctlySpends(tx3, Seq(tx2), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx3.txid == ByteVector32(hex"a474219df20b95210b8dac45bb5ed49f0979f8d9b6c17420f3e50f6abc071af8"))
-    // this tx was published on segnet as a474219df20b95210b8dac45bb5ed49f0979f8d9b6c17420f3e50f6abc071af8
+    assert(tx3.txid == ByteVector32(hex"739e7cba97af259d2c089690adea00aa78b1c8d7995aa9377be58fe5332378aa"))
+    // this tx was published on segnet as 739e7cba97af259d2c089690adea00aa78b1c8d7995aa9377be58fe5332378aa
   }
 
   test("create p2wsh tx") {
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
+    val priv1 = PrivateKey.fromBase58("cV5oyXUgySSMcUvKNdKtuYg4t4NTaxkwYrrocgsJZuYac2ogEdZX", Base58.Prefix.SecretKeyTestnet)._1
     val pub1 = priv1.publicKey
-    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressSegnet, Crypto.hash160(pub1.value).toArray)
+    val address1 = Base58Check.encode(Base58.Prefix.PubkeyAddressTestnet, Crypto.hash160(pub1.value).toArray)
 
-    assert(address1 == "D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap")
+    assert(address1 == "mkNdbutRYE3me7wvbwvvJ8XQwbzi56sneZ")
 
-    val priv2 = PrivateKey.fromBase58("QUpr3G5ia7K7txSq5k7QpgTfNy33iTQWb1nAUgb77xFesn89xsoJ", Base58.Prefix.SecretKeySegnet)._1
+    val priv2 = PrivateKey.fromBase58("cV7LGVeY2VPuCyCSarqEqFCUNig2NzwiAEBTTA89vNRQ4Vqjfurs", Base58.Prefix.SecretKeyTestnet)._1
     val pub2 = priv2.publicKey
 
-    val priv3 = PrivateKey.fromBase58("QX3AN7b3WCAFaiCvAS2UD7HJZBsFU6r5shjfogJu55411hAF3BVx", Base58.Prefix.SecretKeySegnet)._1
+    val priv3 = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)._1
     val pub3 = priv3.publicKey
 
-    // this is a standard tx that sends 0.5 BTC to D6YX7dpieYu8j1bV8B4RgksNmDk3sNJ4Ap
-    val tx1 = Transaction.read("010000000240b4f27534e9d5529e67e52619c7addc88eff64c8e7afc9b41afe9a01c6e2aea010000006b48304502210091aed7fe956c4b2471778bfef5a323a96fee21ec6d73a9b7f363beaad135c5f302207f63b0ffc08fd905cdb87b109416c2d6d8ec56ca25dd52529c931aa1154277f30121037cb5789f1ca6c640b6d423ef71390e0b002da81db8fad4466bf6c2fdfb79a24cfeffffff6e21b8c625d9955e48de0a6bbcd57b03624620a93536ddacabc19d024c330f04010000006a47304402203fb779df3ae2bf8404e6d89f83af3adee0d0a0c4ec5a01a1e88b3aa4313df6490220608177ca82cf4f7da9820a8e8bf4266ccece9eb004e73926e414296d0635d7c1012102edc343e7c422e94cca4c2a87a4f7ce54594c1b68682bbeefa130295e471ac019feffffff0280f0fa02000000001976a9140f66351d05269952302a607b4d6fb69517387a9788ace06d9800000000001976a91457572594090c298721e8dddcec3ac1ec593c6dcc88ac205a0000", pversion)
+    // this is a standard tx that sends 0.05 BTC to mkNdbutRYE3me7wvbwvvJ8XQwbzi56sneZ
+    val tx1 = Transaction.read("020000000001016ecc08b535a0c774234419dee508867ace1535a0d256d6b2aa19942441777336000000002322002073bb471aa121fbdd95942eabb5e665d66e71542e6e075c8392cd0df72a075b72fdffffff02803823030000000017a914d3c15be7951c9de644bdf9e22dcbcb77550c4ae487404b4c00000000001976a9143545b2a6659dbe5bdf841d1158135be184d81d3688ac0400473044022041cac92405e4e3215c2f9c27a67ff0792c8fb76e4182023fed081f541f4563e002203bd04d4d810ef8074aeb26a19e01e1ee1a40ad83e4d0ac2c614b8cb22825d2ae0147304402204c947b46ea480419c04098a56a5219bb1f491b07e12926fb6f304132a1f1e29e022078cc9f004c74d6c3c2b2dfcca6385d2fabe44d4eadb027a0d764e1ab9d7f09190147522102be608bf8904326b4d0ec9346aa348773fe51ee70338849acd2dd710b73bf611a2103627c19e40f67c5ee8b44df85ee911b7e978869fa5a3de1d972a461f47ea349e452ae90bb2300", pversion)
 
     // now let's create a simple tx that spends tx1 and send 0.5 BTC to a P2WSH output
     val tx2 = {
       // our script is a 2-of-2 multisig script
       val redeemScript = Script.createMultiSigMofN(2, Seq(pub2, pub3))
       val tmp = Transaction(version = 1,
-        txIn = TxIn(OutPoint(tx1.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.49 btc, Script.pay2wsh(redeemScript)) :: Nil,
+        txIn = TxIn(OutPoint(tx1.hash, 1), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
+        txOut = TxOut(0.049 btc, Script.pay2wsh(redeemScript)) :: Nil,
         lockTime = 0
       )
-      val sig = Transaction.signInput(tmp, 0, tx1.txOut(0).publicKeyScript, SigHash.SIGHASH_ALL, 0 sat, SigVersion.SIGVERSION_BASE, priv1)
+      val sig = Transaction.signInput(tmp, 0, tx1.txOut(1).publicKeyScript, SigHash.SIGHASH_ALL, 0 sat, SigVersion.SIGVERSION_BASE, priv1)
       tmp.updateSigScript(0, OP_PUSHDATA(sig) :: OP_PUSHDATA(priv1.publicKey) :: Nil)
-      //Transaction.sign(tmp, Seq(SignData(tx1.txOut(0).publicKeyScript, priv1)))
+      //Transaction.sign(tmp, Seq(SignData(tx1.txOut(1).publicKeyScript, priv1)))
     }
     Transaction.correctlySpends(tx2, Seq(tx1), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx2.txid == ByteVector32(hex"9d896b6d2b8fc9665da72f5b1942f924a37c5c714f31f40ee2a6c945f74dd355"))
-    // this tx was published on segnet as 9d896b6d2b8fc9665da72f5b1942f924a37c5c714f31f40ee2a6c945f74dd355
+    assert(tx2.txid == ByteVector32(hex"2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9"))
+    // this tx was published on segnet as 2f8360a06a31ca642d717b1857aa86b3306fc554fa9c437d88b4bc61b7f2b3e9
 
     // and now we create a segwit tx that spends the P2WSH output
     val tx3 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx2.hash, 0), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.48 btc, Script.pay2wpkh(pub1)) :: Nil,
+        txOut = TxOut(0.048 btc, Script.pay2wpkh(pub1)) :: Nil,
         lockTime = 0
       )
       val pubKeyScript = Script.write(Script.createMultiSigMofN(2, Seq(pub2, pub3)))
@@ -155,30 +155,30 @@ class SegwitSpec extends FunSuite {
     }
 
     Transaction.correctlySpends(tx3, Seq(tx2), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx3.txid == ByteVector32(hex"943e07f0c66a9766d0cec81d65a03db4157bc0bfac4d36e400521b947be55aeb"))
-    // this tx was published on segnet as 943e07f0c66a9766d0cec81d65a03db4157bc0bfac4d36e400521b947be55aeb
+    assert(tx3.txid == ByteVector32(hex"4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a"))
+    // this tx was published on segnet as 4817f79def9d9f559ddaa636f0c196e79f31bc959feead77b4151733114c652a
   }
 
   test("create p2pkh embedded in p2sh") {
-    val priv1 = PrivateKey.fromBase58("QRY5zPUH6tWhQr2NwFXNpMbiLQq9u2ztcSZ6RwMPjyKv36rHP2xT", Base58.Prefix.SecretKeySegnet)._1
+    val priv1 = PrivateKey.fromBase58("cRp4uUnreGMZN8vB7nQFX6XWMHU5Lc73HMAhmcDEwHfbgRS66Cqp", Base58.Prefix.SecretKeyTestnet)._1
     val pub1 = priv1.publicKey
 
     // p2wpkh script
     val script = Script.write(Script.pay2wpkh(pub1))
 
-    // which we embeed into a standard p2sh script
-    val p2shaddress = Base58Check.encode(Base58.Prefix.ScriptAddressSegnet, Crypto.hash160(script).toArray)
-    assert(p2shaddress === "MDbNMghDbaaizHz8pSgMqu9qJXvKwouqkM")
+    // which we embed into a standard p2sh script
+    val p2shaddress = Base58Check.encode(Base58.Prefix.ScriptAddressTestnet, Crypto.hash160(script).toArray)
+    assert(p2shaddress === "2NB3GUVxBF3P7NLMkSGNai33mWkM35ht1Xj")
 
-    // this tx send 0.5 btc to our p2shaddress
-    val tx = Transaction.read("010000000175dd435bf25e5d77567272f7d6eefcf37b7156b78bb233490140d6fa7545cfca010000006a47304402206e601a482b301141cb3a1712c18729fa1f1731fce5c4205ac9d344af38bb24bf022003fe70edcbd1a5b3957b3c939e583739eadb8de8d3d2cc2ad2903b19c991cb80012102ba2558223d7cd5df2d8decc4506a62ccaa96159f685360335c280952b25e7adefeffffff02692184df000000001976a9148b3ee15d631122010d31e1774aa318ca9ca8b67088ac80f0fa020000000017a9143e73638f202bb880a28e8df1946adc3058227d11878c730000", pversion)
+    // this tx send 0.05 btc to our p2shaddress
+    val tx = Transaction.read("02000000000101d9ee0034f9ae4fac7a4017d78e26e1c492d507e16f3535ecbc2ea72cb1c4c6f501000000232200208a15b02dab825f2a4b60b58a7c8591c659a3eb18765fd9d926332c0cea574e2ffdffffff02d292e4000000000017a914aefbc2c20e0c312a616cf7c4ebbacc5c9a04432787404b4c000000000017a914c32f5922344dbe1abd4fb1744b560b5d1875353987040047304402205fbba2ab917efc23209fe04086fb5f714e527d088e2a5ec19590ec4b566a8c2d02206607f3e42eaff5d30dd6297dcb4d48300a75819a358c0bc20396e393ab1594260147304402206a0df35cb8fc58fb21b111d432abc7f9f74836ad1e35c63be2f0c772d4a2ce49022076c4c96a7a9d18577a5e762a3dc3e4b728fd950284c133eb3147707b9181f90b01475221039c40944fe4f90f46760621a1ca66d3141f7e81ccccfa2cf4550fdb9b432c52ed2102976af59e7b61fb3c7a6a2553d7b030a5e292fdda6eba439b4a24af494b3475c752aebebb2300", pversion)
 
     // let's spend it:
 
     val tx1 = {
       val tmp: Transaction = Transaction(version = 1,
         txIn = TxIn(OutPoint(tx.hash, 1), sequence = 0xffffffffL, signatureScript = ByteVector.empty) :: Nil,
-        txOut = TxOut(0.49 btc, OP_0 :: OP_PUSHDATA(Crypto.hash160(pub1.value)) :: Nil) :: Nil,
+        txOut = TxOut(0.049 btc, OP_0 :: OP_PUSHDATA(Crypto.hash160(pub1.value)) :: Nil) :: Nil,
         lockTime = 0
       )
       val pubKeyScript = Script.pay2pkh(pub1)
@@ -188,7 +188,7 @@ class SegwitSpec extends FunSuite {
     }
 
     Transaction.correctlySpends(tx1, Seq(tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(tx1.txid === ByteVector32(hex"98f5668176b0c1b14653f96f71987fd325c3d46b9efb677ab0606ea5555791d5"))
-    // this tx was published on segnet as 98f5668176b0c1b14653f96f71987fd325c3d46b9efb677ab0606ea5555791d5
+    assert(tx1.txid === ByteVector32(hex"4807cb10f50df84acd7766245133f902d22d91b7e8bfe77c4bbcb0cf9b017a86"))
+    // this tx was published on segnet as 4807cb10f50df84acd7766245133f902d22d91b7e8bfe77c4bbcb0cf9b017a86
   }
 }


### PR DESCRIPTION
Exposes signet Block hash and blockId from bitcoin-kmp; requires the next version of bitcoin-kmp that includes [PR #61](https://github.com/ACINQ/bitcoin-kmp/pull/61).